### PR TITLE
Add query options for extractWhenMissing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.citrine</groupId>
     <artifactId>jcc</artifactId>
-    <version>1.2.2</version>
+    <version>1.2.3</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.citrine</groupId>
     <artifactId>jcc</artifactId>
-    <version>1.2.3</version>
+    <version>1.2.4</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/io/citrine/jcc/search/pif/query/chemical/ChemicalFieldOperation.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/chemical/ChemicalFieldOperation.java
@@ -71,6 +71,13 @@ public class ChemicalFieldOperation extends BaseFieldOperation implements HasChe
     }
 
     @Override
+    @JsonSetter("extractWhenMissing")
+    public ChemicalFieldOperation extractWhenMissing(final Object extractWhenMissing) {
+        super.extractWhenMissing(extractWhenMissing);
+        return this;
+    }
+
+    @Override
     @JsonIgnore
     public ChemicalFieldOperation length(final FieldOperation fieldOperation) {
         super.length(fieldOperation);

--- a/src/main/java/io/citrine/jcc/search/pif/query/chemical/CompositionQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/chemical/CompositionQuery.java
@@ -372,6 +372,13 @@ public class CompositionQuery extends BaseObjectQuery {
     }
 
     @Override
+    @JsonSetter("extractWhenMissing")
+    public CompositionQuery extractWhenMissing(final Object extractWhenMissing) {
+        super.extractWhenMissing(extractWhenMissing);
+        return this;
+    }
+
+    @Override
     @JsonIgnore
     public CompositionQuery tags(final FieldOperation fieldOperation) {
         super.tags(fieldOperation);

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/BaseFieldOperation.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/BaseFieldOperation.java
@@ -59,6 +59,29 @@ public abstract class BaseFieldOperation {
     }
 
     /**
+     * Set the value to return when an extract value is not found. This value is only returned when an optional query
+     * misses or when a SHOULD query misses but another query in that SHOULD block does hit.
+     *
+     * @param extractWhenMissing Object to return when the overall query is satisfied but the extract value is missing.
+     * @return This object.
+     */
+    @JsonSetter("extractWhenMissing")
+    public BaseFieldOperation extractWhenMissing(final Object extractWhenMissing) {
+        this.extractWhenMissing = extractWhenMissing;
+        return this;
+    }
+
+    /**
+     * Get the value to return whether an extracted value is missing.
+     *
+     * @return Object with the value to return when an extracted value is missing.
+     */
+    @JsonGetter
+    public Object getExtractWhenMissing() {
+        return this.extractWhenMissing;
+    }
+
+    /**
      * Set whether top level filters should be floated. This is intended to be a private method since it should only
      * be used by templates.
      *
@@ -216,6 +239,9 @@ public abstract class BaseFieldOperation {
 
     /** Whether to extract all values in an array. */
     private Boolean extractAll;
+
+    /** Default value to return if a field is missing and the query part is optional. */
+    private Object extractWhenMissing;
 
     /** Set whether top level filters should be floated out into their own objects. */
     private Boolean floatTopFilters;

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/BaseObjectQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/BaseObjectQuery.java
@@ -74,6 +74,29 @@ public abstract class BaseObjectQuery implements HasLogic {
     }
 
     /**
+     * Set the value to return when an extract value is not found. This value is only returned when an optional query
+     * misses or when a SHOULD query misses but another query in that SHOULD block does hit.
+     *
+     * @param extractWhenMissing Object to return when the overall query is satisfied but the extract value is missing.
+     * @return This object.
+     */
+    @JsonSetter("extractWhenMissing")
+    public BaseObjectQuery extractWhenMissing(final Object extractWhenMissing) {
+        this.extractWhenMissing = extractWhenMissing;
+        return this;
+    }
+
+    /**
+     * Get the value to return whether an extracted value is missing.
+     *
+     * @return Object with the value to return when an extracted value is missing.
+     */
+    @JsonGetter
+    public Object getExtractWhenMissing() {
+        return this.extractWhenMissing;
+    }
+
+    /**
      * Set the list of tags operations. This adds to any operations that are already saved.
      *
      * @param tags List of {@link FieldOperation} objects.
@@ -279,6 +302,9 @@ public abstract class BaseObjectQuery implements HasLogic {
 
     /** Whether to extract all values in an array. */
     private Boolean extractAll;
+
+    /** Default value to return if a field is missing and the query part is optional. */
+    private Object extractWhenMissing;
 
     /** List of tag operations. */
     private List<FieldOperation> tags;

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/FieldOperation.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/FieldOperation.java
@@ -68,6 +68,13 @@ public class FieldOperation extends BaseFieldOperation implements HasFilter {
     }
 
     @Override
+    @JsonSetter("extractWhenMissing")
+    public FieldOperation extractWhenMissing(final Object extractWhenMissing) {
+        super.extractWhenMissing(extractWhenMissing);
+        return this;
+    }
+
+    @Override
     @JsonIgnore
     public FieldOperation length(final FieldOperation fieldOperation) {
         super.length(fieldOperation);

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/FileReferenceQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/FileReferenceQuery.java
@@ -36,6 +36,13 @@ public class FileReferenceQuery extends BaseObjectQuery {
         return this;
     }
 
+    @Override
+    @JsonSetter("extractWhenMissing")
+    public FileReferenceQuery extractWhenMissing(final Object extractWhenMissing) {
+        super.extractWhenMissing(extractWhenMissing);
+        return this;
+    }
+
     /**
      * Set the list of relative path operations. This adds to any operations that are already saved.
      *

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/IdQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/IdQuery.java
@@ -36,6 +36,13 @@ public class IdQuery extends BaseObjectQuery {
         return this;
     }
 
+    @Override
+    @JsonSetter("extractWhenMissing")
+    public IdQuery extractWhenMissing(final Object extractWhenMissing) {
+        super.extractWhenMissing(extractWhenMissing);
+        return this;
+    }
+
     /**
      * Set the list of id name operations. This adds to any operations that are already saved.
      *

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/NameQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/NameQuery.java
@@ -36,6 +36,13 @@ public class NameQuery extends BaseObjectQuery {
         return this;
     }
 
+    @Override
+    @JsonSetter("extractWhenMissing")
+    public NameQuery extractWhenMissing(final Object extractWhenMissing) {
+        super.extractWhenMissing(extractWhenMissing);
+        return this;
+    }
+
     /**
      * Set the list of given name operations. This adds to any operations that are already saved.
      *

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/PagesQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/PagesQuery.java
@@ -37,6 +37,13 @@ public class PagesQuery extends BaseObjectQuery {
         return this;
     }
 
+    @Override
+    @JsonSetter("extractWhenMissing")
+    public PagesQuery extractWhenMissing(final Object extractWhenMissing) {
+        super.extractWhenMissing(extractWhenMissing);
+        return this;
+    }
+
     /**
      * Set the list of starting page operations. This adds to any operations that are already saved.
      *

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/ProcessStepQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/ProcessStepQuery.java
@@ -145,6 +145,13 @@ public class ProcessStepQuery extends BaseObjectQuery {
     }
 
     @Override
+    @JsonSetter("extractWhenMissing")
+    public ProcessStepQuery extractWhenMissing(final Object extractWhenMissing) {
+        super.extractWhenMissing(extractWhenMissing);
+        return this;
+    }
+
+    @Override
     @JsonIgnore
     public ProcessStepQuery tags(final FieldOperation fieldOperation) {
         super.tags(fieldOperation);

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/PropertyQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/PropertyQuery.java
@@ -37,6 +37,13 @@ public class PropertyQuery extends ValueQuery {
     }
 
     @Override
+    @JsonSetter("extractWhenMissing")
+    public PropertyQuery extractWhenMissing(final Object extractWhenMissing) {
+        super.extractWhenMissing(extractWhenMissing);
+        return this;
+    }
+
+    @Override
     @JsonIgnore
     public PropertyQuery name(final FieldOperation fieldOperation) {
         super.name(fieldOperation);

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/QuantityQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/QuantityQuery.java
@@ -433,6 +433,13 @@ public class QuantityQuery extends BaseObjectQuery {
     }
 
     @Override
+    @JsonSetter("extractWhenMissing")
+    public QuantityQuery extractWhenMissing(final Object extractWhenMissing) {
+        super.extractWhenMissing(extractWhenMissing);
+        return this;
+    }
+
+    @Override
     @JsonIgnore
     public QuantityQuery tags(final FieldOperation fieldOperation) {
         super.tags(fieldOperation);

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/ReferenceQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/ReferenceQuery.java
@@ -997,6 +997,13 @@ public class ReferenceQuery extends BaseObjectQuery {
     }
 
     @Override
+    @JsonSetter("extractWhenMissing")
+    public ReferenceQuery extractWhenMissing(final Object extractWhenMissing) {
+        super.extractWhenMissing(extractWhenMissing);
+        return this;
+    }
+
+    @Override
     @JsonIgnore
     public ReferenceQuery tags(final FieldOperation fieldOperation) {
         super.tags(fieldOperation);

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/SourceQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/SourceQuery.java
@@ -169,6 +169,13 @@ public class SourceQuery extends BaseObjectQuery {
     }
 
     @Override
+    @JsonSetter("extractWhenMissing")
+    public SourceQuery extractWhenMissing(final Object extractWhenMissing) {
+        super.extractWhenMissing(extractWhenMissing);
+        return this;
+    }
+
+    @Override
     @JsonIgnore
     public SourceQuery tags(final FieldOperation fieldOperation) {
         super.tags(fieldOperation);

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/SystemQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/SystemQuery.java
@@ -508,6 +508,13 @@ public class SystemQuery extends BaseObjectQuery {
     }
 
     @Override
+    @JsonSetter("extractWhenMissing")
+    public SystemQuery extractWhenMissing(final Object extractWhenMissing) {
+        super.extractWhenMissing(extractWhenMissing);
+        return this;
+    }
+
+    @Override
     @JsonIgnore
     public SystemQuery tags(final FieldOperation fieldOperation) {
         super.tags(fieldOperation);

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/ValueQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/ValueQuery.java
@@ -267,6 +267,13 @@ public class ValueQuery extends BaseObjectQuery {
     }
 
     @Override
+    @JsonSetter("extractWhenMissing")
+    public ValueQuery extractWhenMissing(final Object extractWhenMissing) {
+        super.extractWhenMissing(extractWhenMissing);
+        return this;
+    }
+
+    @Override
     @JsonIgnore
     public ValueQuery tags(final FieldOperation fieldOperation) {
         super.tags(fieldOperation);


### PR DESCRIPTION
This adds an extractWhenMissing field to all query objects that have an extractAs field. If the query hits, but that particular part of the query does not (has SHOULD or OPTIONAL logic), then the extractWhenMissing value will be added under the extractAs field.