### PR TITLE
Scrubbing unnecessary JsonIgnore annotations that break scala mappers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.citrine</groupId>
     <artifactId>jcc</artifactId>
-    <version>2.1.0</version>
+    <version>2.1.1</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/io/citrine/jcc/search/core/query/BaseReturningQuery.java
+++ b/src/main/java/io/citrine/jcc/search/core/query/BaseReturningQuery.java
@@ -1,6 +1,5 @@
 package io.citrine.jcc.search.core.query;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSetter;
 
 import java.util.List;
@@ -19,14 +18,14 @@ public abstract class BaseReturningQuery extends DataScope {
     }
 
     @Override
-    @JsonIgnore
+
     public BaseReturningQuery addQuery(final List<DataQuery> query) {
         super.addQuery(query);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public BaseReturningQuery addQuery(final DataQuery query) {
         super.addQuery(query);
         return this;
@@ -69,7 +68,7 @@ public abstract class BaseReturningQuery extends DataScope {
      *
      * @return Index of the first hit that should be returned or a null pointer if not set.
      */
-    @JsonIgnore
+
     public Integer getFrom() {
         return this.from;
     }

--- a/src/main/java/io/citrine/jcc/search/core/query/BooleanFilter.java
+++ b/src/main/java/io/citrine/jcc/search/core/query/BooleanFilter.java
@@ -91,7 +91,7 @@ public class BooleanFilter implements HasLogic {
      * @param filter List of {@link BooleanFilter} objects to save.
      * @return This object.
      */
-    @JsonIgnore
+
     public BooleanFilter addFilter(final List<BooleanFilter> filter) {
         this.filter = ListUtil.add(filter, this.filter);
         return this;
@@ -103,7 +103,7 @@ public class BooleanFilter implements HasLogic {
      * @param filter {@link Filter} object to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public BooleanFilter addFilter(final BooleanFilter filter) {
         this.filter = ListUtil.add(filter, this.filter);
         return this;
@@ -114,7 +114,7 @@ public class BooleanFilter implements HasLogic {
      *
      * @return Number of filters.
      */
-    @JsonIgnore
+
     public int filterLength() {
         return ListUtil.length(this.filter);
     }
@@ -124,7 +124,7 @@ public class BooleanFilter implements HasLogic {
      *
      * @return Iterable of {@link Filter} objects.
      */
-    @JsonIgnore
+
     public Iterable<BooleanFilter> filter() {
         return ListUtil.iterable(this.filter);
     }
@@ -135,7 +135,7 @@ public class BooleanFilter implements HasLogic {
      * @param index Index of the filter to get.
      * @return Filter at the input index.
      */
-    @JsonIgnore
+
     public BooleanFilter getFilter(final int index) {
         return ListUtil.get(this.filter, index);
     }

--- a/src/main/java/io/citrine/jcc/search/core/query/DataQuery.java
+++ b/src/main/java/io/citrine/jcc/search/core/query/DataQuery.java
@@ -1,6 +1,5 @@
 package io.citrine.jcc.search.core.query;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.citrine.jcc.search.dataset.query.DatasetQuery;
 import io.citrine.jcc.search.pif.query.PifSystemQuery;
 import io.citrine.jcc.util.ListUtil;
@@ -42,7 +41,7 @@ public class DataQuery implements HasLogic {
      * @param dataset List of {@link DatasetQuery} objects.
      * @return This object.
      */
-    @JsonIgnore
+
     public DataQuery addDataset(final List<DatasetQuery> dataset) {
         this.dataset = ListUtil.add(dataset, this.dataset);
         return this;
@@ -54,7 +53,7 @@ public class DataQuery implements HasLogic {
      * @param dataset {@link DatasetQuery} object to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public DataQuery addDataset(final DatasetQuery dataset) {
         this.dataset = ListUtil.add(dataset, this.dataset);
         return this;
@@ -65,7 +64,7 @@ public class DataQuery implements HasLogic {
      *
      * @return Number of queries against the dataset field.
      */
-    @JsonIgnore
+
     public int datasetLength() {
         return ListUtil.length(this.dataset);
     }
@@ -75,7 +74,6 @@ public class DataQuery implements HasLogic {
      *
      * @return {@link Iterable} of {@link DatasetQuery} objects.
      */
-    @JsonIgnore
     public Iterable<DatasetQuery> dataset() {
         return ListUtil.iterable(this.dataset);
     }
@@ -86,7 +84,6 @@ public class DataQuery implements HasLogic {
      * @param index Index of the dataset query to get.
      * @return {@link DatasetQuery} at the input index.
      */
-    @JsonIgnore
     public DatasetQuery getDataset(final int index) {
         return ListUtil.get(this.dataset, index);
     }
@@ -117,7 +114,7 @@ public class DataQuery implements HasLogic {
      * @param system List of {@link PifSystemQuery} objects.
      * @return This object.
      */
-    @JsonIgnore
+
     public DataQuery addSystem(final List<PifSystemQuery> system) {
         this.system = ListUtil.add(system, this.system);
         return this;
@@ -129,7 +126,7 @@ public class DataQuery implements HasLogic {
      * @param system {@link PifSystemQuery} object to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public DataQuery addSystem(final PifSystemQuery system) {
         this.system = ListUtil.add(system, this.system);
         return this;
@@ -140,7 +137,7 @@ public class DataQuery implements HasLogic {
      *
      * @return Number of queries against the system field.
      */
-    @JsonIgnore
+
     public int systemLength() {
         return ListUtil.length(this.system);
     }
@@ -150,7 +147,7 @@ public class DataQuery implements HasLogic {
      *
      * @return {@link Iterable} of {@link PifSystemQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<PifSystemQuery> system() {
         return ListUtil.iterable(this.system);
     }
@@ -161,7 +158,6 @@ public class DataQuery implements HasLogic {
      * @param index Index of the system to get.
      * @return {@link PifSystemQuery} at the input index.
      */
-    @JsonIgnore
     public PifSystemQuery getSystem(final int index) {
         return ListUtil.get(this.system, index);
     }

--- a/src/main/java/io/citrine/jcc/search/core/query/DataScope.java
+++ b/src/main/java/io/citrine/jcc/search/core/query/DataScope.java
@@ -29,7 +29,7 @@ public class DataScope {
      * @param query List of {@link DataQuery} objects.
      * @return This object.
      */
-    @JsonIgnore
+
     public DataScope addQuery(final List<DataQuery> query) {
         this.query = ListUtil.add(query, this.query);
         return this;
@@ -41,7 +41,7 @@ public class DataScope {
      * @param query {@link DataQuery} object to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public DataScope addQuery(final DataQuery query) {
         this.query = ListUtil.add(query, this.query);
         return this;
@@ -52,7 +52,7 @@ public class DataScope {
      *
      * @return Number of queries.
      */
-    @JsonIgnore
+
     public int queryLength() {
         return ListUtil.length(this.query);
     }
@@ -62,7 +62,6 @@ public class DataScope {
      *
      * @return {@link Iterable} of {@link DataQuery} objects.
      */
-    @JsonIgnore
     public Iterable<DataQuery> query() {
         return ListUtil.iterable(this.query);
     }
@@ -73,7 +72,6 @@ public class DataScope {
      * @param index Index of the query to get.
      * @return {@link DataQuery} at the input index.
      */
-    @JsonIgnore
     public DataQuery getQuery(final int index) {
         return ListUtil.get(this.query, index);
     }

--- a/src/main/java/io/citrine/jcc/search/core/query/Filter.java
+++ b/src/main/java/io/citrine/jcc/search/core/query/Filter.java
@@ -32,33 +32,33 @@ public class Filter implements HasLogic, HasFilter {
     }
 
     @Override
-    @JsonIgnore
+
     public Filter addFilter(final List<Filter> filter) {
         this.filter = ListUtil.add(filter, this.filter);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public Filter addFilter(final Filter filter) {
         this.filter = ListUtil.add(filter, this.filter);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public int filterLength() {
         return ListUtil.length(this.filter);
     }
 
     @Override
-    @JsonIgnore
+
     public Iterable<Filter> filter() {
         return ListUtil.iterable(this.filter);
     }
 
     @Override
-    @JsonIgnore
+
     public Filter getFilter(final int index) {
         return ListUtil.get(this.filter, index);
     }
@@ -126,7 +126,7 @@ public class Filter implements HasLogic, HasFilter {
      * @param min Minimum value that should match.
      * @return This object.
      */
-    @JsonIgnore
+
     public Filter setMin(final Integer min) {
         this.min = Integer.toString(min);
         return this;
@@ -138,7 +138,7 @@ public class Filter implements HasLogic, HasFilter {
      * @param min Minimum value that should match.
      * @return This object.
      */
-    @JsonIgnore
+
     public Filter setMin(final Long min) {
         this.min = Long.toString(min);
         return this;
@@ -150,7 +150,7 @@ public class Filter implements HasLogic, HasFilter {
      * @param min Minimum value that should match.
      * @return This object.
      */
-    @JsonIgnore
+
     public Filter setMin(final Float min) {
         this.min = Float.toString(min);
         return this;
@@ -162,7 +162,7 @@ public class Filter implements HasLogic, HasFilter {
      * @param min Minimum value that should match.
      * @return This object.
      */
-    @JsonIgnore
+
     public Filter setMin(final Double min) {
         this.min = Double.toString(min);
         return this;
@@ -196,7 +196,7 @@ public class Filter implements HasLogic, HasFilter {
      * @param max Maximum value that should match.
      * @return This object.
      */
-    @JsonIgnore
+
     public Filter setMax(final Integer max) {
         this.max = Integer.toString(max);
         return this;
@@ -208,7 +208,7 @@ public class Filter implements HasLogic, HasFilter {
      * @param max Maximum value that should match.
      * @return This object.
      */
-    @JsonIgnore
+
     public Filter setMax(final Long max) {
         this.max = Long.toString(max);
         return this;
@@ -220,7 +220,7 @@ public class Filter implements HasLogic, HasFilter {
      * @param max Maximum value that should match.
      * @return This object.
      */
-    @JsonIgnore
+
     public Filter setMax(final Float max) {
         this.max = Float.toString(max);
         return this;
@@ -232,7 +232,7 @@ public class Filter implements HasLogic, HasFilter {
      * @param max Maximum value that should match.
      * @return This object.
      */
-    @JsonIgnore
+
     public Filter setMax(final Double max) {
         this.max = Double.toString(max);
         return this;

--- a/src/main/java/io/citrine/jcc/search/core/query/HasFilter.java
+++ b/src/main/java/io/citrine/jcc/search/core/query/HasFilter.java
@@ -25,7 +25,7 @@ public interface HasFilter {
      * @param filter List of {@link Filter} objects to save.
      * @return This object.
      */
-    @JsonIgnore
+
     HasFilter addFilter(final List<Filter> filter);
 
     /**
@@ -34,7 +34,7 @@ public interface HasFilter {
      * @param filter {@link Filter} object to add.
      * @return This object.
      */
-    @JsonIgnore
+
     HasFilter addFilter(final Filter filter);
 
     /**
@@ -42,7 +42,7 @@ public interface HasFilter {
      *
      * @return Number of filters.
      */
-    @JsonIgnore
+
     int filterLength();
 
     /**
@@ -50,7 +50,7 @@ public interface HasFilter {
      *
      * @return Iterable of {@link Filter} objects.
      */
-    @JsonIgnore
+
     Iterable<Filter> filter();
 
     /**
@@ -59,7 +59,7 @@ public interface HasFilter {
      * @param index Index of the filter to get.
      * @return Filter at the input index.
      */
-    @JsonIgnore
+
     Filter getFilter(final int index);
 
     /**

--- a/src/main/java/io/citrine/jcc/search/core/query/MultiQuery.java
+++ b/src/main/java/io/citrine/jcc/search/core/query/MultiQuery.java
@@ -30,7 +30,7 @@ public class MultiQuery<T> {
      * @param queries List of queries to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public MultiQuery<T> addQueries(final List<T> queries) {
         this.queries = ListUtil.add(queries, this.queries);
         return this;
@@ -42,7 +42,7 @@ public class MultiQuery<T> {
      * @param query Query to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public MultiQuery<T> addQueries(final T query) {
         this.queries = ListUtil.add(query, this.queries);
         return this;
@@ -53,7 +53,7 @@ public class MultiQuery<T> {
      *
      * @return Number of queries.
      */
-    @JsonIgnore
+
     public int queriesLength() {
         return ListUtil.length(this.queries);
     }
@@ -63,7 +63,7 @@ public class MultiQuery<T> {
      *
      * @return {@link Iterable} over the queries.
      */
-    @JsonIgnore
+
     public Iterable<T> queries() {
         return ListUtil.iterable(this.queries);
     }
@@ -75,7 +75,7 @@ public class MultiQuery<T> {
      * @return Query at the input index.
      * @throws IllegalArgumentException if the index is out of bounds.
      */
-    @JsonIgnore
+
     public T getQueries(final int index) {
         return ListUtil.get(this.queries, index);
     }

--- a/src/main/java/io/citrine/jcc/search/core/query/MultiSearchResult.java
+++ b/src/main/java/io/citrine/jcc/search/core/query/MultiSearchResult.java
@@ -54,7 +54,7 @@ public class MultiSearchResult<T extends BaseSearchResult<?>> implements Iterabl
      * @param results List of {@link MultiSearchResultElement} objects to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public MultiSearchResult<T> addResults(final List<MultiSearchResultElement<T>> results) {
         this.results = ListUtil.add(results, this.results);
         return this;
@@ -66,7 +66,7 @@ public class MultiSearchResult<T extends BaseSearchResult<?>> implements Iterabl
      * @param result Result to add to the results set.
      * @return This object.
      */
-    @JsonIgnore
+
     public MultiSearchResult<T> addResults(final MultiSearchResultElement<T> result) {
         this.results = ListUtil.add(result, this.results);
         return this;
@@ -77,7 +77,7 @@ public class MultiSearchResult<T extends BaseSearchResult<?>> implements Iterabl
      *
      * @return Number of results in the returned set.
      */
-    @JsonIgnore
+
     public int resultsLength() {
         return ListUtil.length(this.results);
     }
@@ -89,7 +89,7 @@ public class MultiSearchResult<T extends BaseSearchResult<?>> implements Iterabl
      * @return Result at the input index.
      * @throws IllegalArgumentException if the index is out of bounds.
      */
-    @JsonIgnore
+
     public MultiSearchResultElement<T> getResults(final int index) {
         return ListUtil.get(this.results, index);
     }
@@ -104,7 +104,7 @@ public class MultiSearchResult<T extends BaseSearchResult<?>> implements Iterabl
     }
 
     @Override
-    @JsonIgnore
+
     public Iterator<MultiSearchResultElement<T>> iterator() {
         return (this.results == null) ? Collections.emptyIterator() : this.results.iterator();
     }

--- a/src/main/java/io/citrine/jcc/search/core/result/BaseSearchResult.java
+++ b/src/main/java/io/citrine/jcc/search/core/result/BaseSearchResult.java
@@ -94,7 +94,7 @@ public abstract class BaseSearchResult<T> implements Iterable<T>  {
      * @param hits List of hits to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public BaseSearchResult<T> addHits(final List<T> hits) {
         this.hits = ListUtil.add(hits, this.hits);
         return this;
@@ -106,7 +106,7 @@ public abstract class BaseSearchResult<T> implements Iterable<T>  {
      * @param hit Hit to add to the results set.
      * @return This object.
      */
-    @JsonIgnore
+
     public BaseSearchResult<T> addHits(final T hit) {
         this.hits = ListUtil.add(hit, this.hits);
         return this;
@@ -117,7 +117,7 @@ public abstract class BaseSearchResult<T> implements Iterable<T>  {
      *
      * @return Number of hits in the result set.
      */
-    @JsonIgnore
+
     public int getNumHits() {
         return ListUtil.length(this.hits);
     }
@@ -129,7 +129,7 @@ public abstract class BaseSearchResult<T> implements Iterable<T>  {
      * @return Hit at the input index.
      * @throws IllegalArgumentException if the index is out of bounds.
      */
-    @JsonIgnore
+
     public T getHits(final int index) {
         return ListUtil.get(this.hits, index);
     }
@@ -144,7 +144,7 @@ public abstract class BaseSearchResult<T> implements Iterable<T>  {
     }
 
     @Override
-    @JsonIgnore
+
     public Iterator<T> iterator() {
         return (this.hits == null) ? Collections.emptyIterator() : this.hits.iterator();
     }

--- a/src/main/java/io/citrine/jcc/search/dataset/query/DatasetQuery.java
+++ b/src/main/java/io/citrine/jcc/search/dataset/query/DatasetQuery.java
@@ -44,7 +44,7 @@ public class DatasetQuery implements HasLogic {
      * @param id List of {@link Filter} objects.
      * @return This object.
      */
-    @JsonIgnore
+
     public DatasetQuery addId(final List<Filter> id) {
         this.id = ListUtil.add(id, this.id);
         return this;
@@ -56,7 +56,7 @@ public class DatasetQuery implements HasLogic {
      * @param id {@link Filter} object to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public DatasetQuery addId(final Filter id) {
         this.id = ListUtil.add(id, this.id);
         return this;
@@ -67,7 +67,7 @@ public class DatasetQuery implements HasLogic {
      *
      * @return Number of queries against the datasetId field.
      */
-    @JsonIgnore
+
     public int idLength() {
         return ListUtil.length(this.id);
     }
@@ -77,7 +77,7 @@ public class DatasetQuery implements HasLogic {
      *
      * @return {@link Iterable} of {@link Filter} objects.
      */
-    @JsonIgnore
+
     public Iterable<Filter> id() {
         return ListUtil.iterable(this.id);
     }
@@ -88,7 +88,7 @@ public class DatasetQuery implements HasLogic {
      * @param index Index of the dataset ID filter to get.
      * @return {@link Filter} at the input index.
      */
-    @JsonIgnore
+
     public Filter getId(final int index) {
         return ListUtil.get(this.id, index);
     }
@@ -119,7 +119,7 @@ public class DatasetQuery implements HasLogic {
      * @param isFeatured List of {@link BooleanFilter} objects.
      * @return This object.
      */
-    @JsonIgnore
+
     public DatasetQuery addIsFeatured(final List<BooleanFilter> isFeatured) {
         this.isFeatured = ListUtil.add(isFeatured, this.isFeatured);
         return this;
@@ -131,7 +131,7 @@ public class DatasetQuery implements HasLogic {
      * @param isFeatured {@link BooleanFilter} object to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public DatasetQuery addIsFeatured(final BooleanFilter isFeatured) {
         this.isFeatured = ListUtil.add(isFeatured, this.isFeatured);
         return this;
@@ -142,7 +142,7 @@ public class DatasetQuery implements HasLogic {
      * 
      * @return Number of isFeatured queries.
      */
-    @JsonIgnore
+
     public int isFeaturedLength() {
         return ListUtil.length(this.isFeatured);
     }
@@ -152,7 +152,7 @@ public class DatasetQuery implements HasLogic {
      * 
      * @return {@link Iterable} of {@link BooleanFilter} objects.
      */
-    @JsonIgnore
+
     public Iterable<BooleanFilter> isFeatured() {
         return ListUtil.iterable(this.isFeatured);
     }
@@ -163,7 +163,7 @@ public class DatasetQuery implements HasLogic {
      * @param index Index of the filter to get.
      * @return {@link BooleanFilter} object.
      */
-    @JsonIgnore
+
     public BooleanFilter getIsFeatured(final int index) {
         return ListUtil.get(this.isFeatured, index);
     }
@@ -194,7 +194,7 @@ public class DatasetQuery implements HasLogic {
      * @param name List of {@link Filter} objects.
      * @return This object.
      */
-    @JsonIgnore
+
     public DatasetQuery addName(final List<Filter> name) {
         this.name = ListUtil.add(name, this.name);
         return this;
@@ -206,7 +206,7 @@ public class DatasetQuery implements HasLogic {
      * @param name {@link Filter} object to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public DatasetQuery addName(final Filter name) {
         this.name = ListUtil.add(name, this.name);
         return this;
@@ -217,7 +217,7 @@ public class DatasetQuery implements HasLogic {
      *
      * @return Number of queries against the name field.
      */
-    @JsonIgnore
+
     public int nameLength() {
         return ListUtil.length(this.name);
     }
@@ -227,7 +227,7 @@ public class DatasetQuery implements HasLogic {
      *
      * @return {@link Iterable} of {@link Filter} objects.
      */
-    @JsonIgnore
+
     public Iterable<Filter> name() {
         return ListUtil.iterable(this.name);
     }
@@ -238,7 +238,7 @@ public class DatasetQuery implements HasLogic {
      * @param index Index of the filter to get.
      * @return {@link Filter} object.
      */
-    @JsonIgnore
+
     public Filter getName(final int index) {
         return ListUtil.get(this.name, index);
     }
@@ -269,7 +269,7 @@ public class DatasetQuery implements HasLogic {
      * @param description List of {@link Filter} objects.
      * @return This object.
      */
-    @JsonIgnore
+
     public DatasetQuery addDescription(final List<Filter> description) {
         this.description = ListUtil.add(description, this.description);
         return this;
@@ -281,7 +281,7 @@ public class DatasetQuery implements HasLogic {
      * @param description {@link Filter} object to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public DatasetQuery addDescription(final Filter description) {
         this.description = ListUtil.add(description, this.description);
         return this;
@@ -292,7 +292,7 @@ public class DatasetQuery implements HasLogic {
      *
      * @return Number of queries against the description field.
      */
-    @JsonIgnore
+
     public int descriptionLength() {
         return ListUtil.length(this.description);
     }
@@ -302,7 +302,7 @@ public class DatasetQuery implements HasLogic {
      *
      * @return {@link Iterable} of {@link Filter} objects.
      */
-    @JsonIgnore
+
     public Iterable<Filter> description() {
         return ListUtil.iterable(this.description);
     }
@@ -313,7 +313,7 @@ public class DatasetQuery implements HasLogic {
      * @param index Index of the filter to get.
      * @return {@link Filter} object.
      */
-    @JsonIgnore
+
     public Filter getDescription(final int index) {
         return ListUtil.get(this.description, index);
     }
@@ -344,7 +344,7 @@ public class DatasetQuery implements HasLogic {
      * @param owner List of {@link Filter} objects.
      * @return This object.
      */
-    @JsonIgnore
+
     public DatasetQuery addOwner(final List<Filter> owner) {
         this.owner = ListUtil.add(owner, this.owner);
         return this;
@@ -356,7 +356,7 @@ public class DatasetQuery implements HasLogic {
      * @param owner {@link Filter} object to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public DatasetQuery addOwner(final Filter owner) {
         this.owner = ListUtil.add(owner, this.owner);
         return this;
@@ -367,7 +367,7 @@ public class DatasetQuery implements HasLogic {
      *
      * @return Number of queries against the owner field.
      */
-    @JsonIgnore
+
     public int ownerLength() {
         return ListUtil.length(this.owner);
     }
@@ -377,7 +377,7 @@ public class DatasetQuery implements HasLogic {
      *
      * @return {@link Iterable} of {@link Filter} objects.
      */
-    @JsonIgnore
+
     public Iterable<Filter> owner() {
         return ListUtil.iterable(this.owner);
     }
@@ -388,7 +388,7 @@ public class DatasetQuery implements HasLogic {
      * @param index Index of the owner query to get.
      * @return {@link Filter} object.
      */
-    @JsonIgnore
+
     public Filter getOwner(final int index) {
         return ListUtil.get(this.owner, index);
     }
@@ -419,7 +419,7 @@ public class DatasetQuery implements HasLogic {
      * @param email List of {@link Filter} objects.
      * @return This object.
      */
-    @JsonIgnore
+
     public DatasetQuery addEmail(final List<Filter> email) {
         this.email = ListUtil.add(email, this.email);
         return this;
@@ -431,7 +431,7 @@ public class DatasetQuery implements HasLogic {
      * @param email {@link Filter} object to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public DatasetQuery addEmail(final Filter email) {
         this.email = ListUtil.add(email, this.email);
         return this;
@@ -442,7 +442,7 @@ public class DatasetQuery implements HasLogic {
      *
      * @return Number of queries against the email field.
      */
-    @JsonIgnore
+
     public int emailLength() {
         return ListUtil.length(this.email);
     }
@@ -452,7 +452,7 @@ public class DatasetQuery implements HasLogic {
      *
      * @return {@link Iterable} of {@link Filter} objects.
      */
-    @JsonIgnore
+
     public Iterable<Filter> email() {
         return ListUtil.iterable(this.email);
     }
@@ -463,7 +463,7 @@ public class DatasetQuery implements HasLogic {
      * @param index Index of the email query to get.
      * @return {@link Filter} object.
      */
-    @JsonIgnore
+
     public Filter getEmail(final int index) {
         return ListUtil.get(this.email, index);
     }

--- a/src/main/java/io/citrine/jcc/search/dataset/query/DatasetReturningQuery.java
+++ b/src/main/java/io/citrine/jcc/search/dataset/query/DatasetReturningQuery.java
@@ -66,14 +66,14 @@ public class DatasetReturningQuery extends BaseReturningQuery {
     }
 
     @Override
-    @JsonIgnore
+
     public DatasetReturningQuery addQuery(final List<DataQuery> query) {
         super.addQuery(query);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public DatasetReturningQuery addQuery(final DataQuery query) {
         super.addQuery(query);
         return this;

--- a/src/main/java/io/citrine/jcc/search/dataset/result/DatasetSearchResult.java
+++ b/src/main/java/io/citrine/jcc/search/dataset/result/DatasetSearchResult.java
@@ -47,14 +47,14 @@ public class DatasetSearchResult extends BaseSearchResult<DatasetSearchHit>  {
     }
 
     @Override
-    @JsonIgnore
+
     public DatasetSearchResult addHits(final List<DatasetSearchHit> hits) {
         super.addHits(hits);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public DatasetSearchResult addHits(final DatasetSearchHit hit) {
         super.addHits(hit);
         return this;

--- a/src/main/java/io/citrine/jcc/search/pif/query/PifSystemQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/PifSystemQuery.java
@@ -56,14 +56,14 @@ public class PifSystemQuery extends BaseObjectQuery {
     }
 
     @Override
-    @JsonIgnore
+
     public PifSystemQuery addTags(final List<FieldQuery> tags) {
         super.addTags(tags);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public PifSystemQuery addTags(final FieldQuery tags) {
         super.addTags(tags);
         return this;
@@ -76,14 +76,14 @@ public class PifSystemQuery extends BaseObjectQuery {
     }
 
     @Override
-    @JsonIgnore
+
     public PifSystemQuery addLength(final List<FieldQuery> length) {
         super.addLength(length);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public PifSystemQuery addLength(final FieldQuery length) {
         super.addLength(length);
         return this;
@@ -96,14 +96,14 @@ public class PifSystemQuery extends BaseObjectQuery {
     }
 
     @Override
-    @JsonIgnore
+
     public PifSystemQuery addOffset(final List<FieldQuery> offset) {
         super.addOffset(offset);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public PifSystemQuery addOffset(final FieldQuery offset) {
         super.addOffset(offset);
         return this;
@@ -126,7 +126,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      * @param uid List of {@link Filter} objects.
      * @return This object.
      */
-    @JsonIgnore
+
     public PifSystemQuery addUid(final List<Filter> uid) {
         this.uid = ListUtil.add(uid, this.uid);
         return this;
@@ -138,7 +138,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      * @param uid {@link Filter} object to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public PifSystemQuery addUid(final Filter uid) {
         this.uid = ListUtil.add(uid, this.uid);
         return this;
@@ -149,7 +149,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      *
      * @return Number of queries against the system UID field.
      */
-    @JsonIgnore
+
     public int uidLength() {
         return ListUtil.length(this.uid);
     }
@@ -159,7 +159,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      *
      * @return {@link Iterable} of {@link Filter} objects.
      */
-    @JsonIgnore
+
     public Iterable<Filter> uid() {
         return ListUtil.iterable(this.uid);
     }
@@ -170,7 +170,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      * @param index Index of the system UID filter to get.
      * @return {@link Filter} at the input index.
      */
-    @JsonIgnore
+
     public Filter getUid(final int index) {
         return ListUtil.get(this.uid, index);
     }
@@ -201,7 +201,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      * @param names {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public PifSystemQuery addNames(final List<FieldQuery> names) {
         this.names = ListUtil.add(names, this.names);
         return this;
@@ -213,7 +213,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      * @param names {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public PifSystemQuery addNames(final FieldQuery names) {
         this.names = ListUtil.add(names, this.names);
         return this;
@@ -224,7 +224,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      *
      * @return Number of names queries.
      */
-    @JsonIgnore
+
     public int namesLength() {
         return ListUtil.length(this.names);
     }
@@ -234,7 +234,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> names() {
         return ListUtil.iterable(this.names);
     }
@@ -245,7 +245,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      * @param index Index of the names query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getNames(final int index) {
         return ListUtil.get(this.names, index);
     }
@@ -276,7 +276,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      * @param ids {@link IdQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public PifSystemQuery addIds(final List<IdQuery> ids) {
         this.ids = ListUtil.add(ids, this.ids);
         return this;
@@ -288,7 +288,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      * @param ids {@link IdQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public PifSystemQuery addIds(final IdQuery ids) {
         this.ids = ListUtil.add(ids, this.ids);
         return this;
@@ -299,7 +299,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      *
      * @return Number of ids queries.
      */
-    @JsonIgnore
+
     public int idsLength() {
         return ListUtil.length(this.ids);
     }
@@ -309,7 +309,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link IdQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<IdQuery> ids() {
         return ListUtil.iterable(this.ids);
     }
@@ -320,7 +320,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      * @param index Index of the ids query to get.
      * @return {@link IdQuery} at the input index.
      */
-    @JsonIgnore
+
     public IdQuery getIds(final int index) {
         return ListUtil.get(this.ids, index);
     }
@@ -351,7 +351,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      * @param classifications {@link ClassificationQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public PifSystemQuery addClassifications(final List<ClassificationQuery> classifications) {
         this.classifications = ListUtil.add(classifications, this.classifications);
         return this;
@@ -363,7 +363,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      * @param classifications {@link ClassificationQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public PifSystemQuery addClassifications(final ClassificationQuery classifications) {
         this.classifications = ListUtil.add(classifications, this.classifications);
         return this;
@@ -374,7 +374,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      *
      * @return Number of classifications queries.
      */
-    @JsonIgnore
+
     public int classificationsLength() {
         return ListUtil.length(this.classifications);
     }
@@ -384,7 +384,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link ClassificationQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<ClassificationQuery> classifications() {
         return ListUtil.iterable(this.classifications);
     }
@@ -395,7 +395,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      * @param index Index of the classifications query to get.
      * @return {@link ClassificationQuery} at the input index.
      */
-    @JsonIgnore
+
     public ClassificationQuery getClassifications(final int index) {
         return ListUtil.get(this.classifications, index);
     }
@@ -426,7 +426,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      * @param source {@link SourceQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public PifSystemQuery addSource(final List<SourceQuery> source) {
         this.source = ListUtil.add(source, this.source);
         return this;
@@ -438,7 +438,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      * @param source {@link SourceQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public PifSystemQuery addSource(final SourceQuery source) {
         this.source = ListUtil.add(source, this.source);
         return this;
@@ -449,7 +449,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      *
      * @return Number of source queries.
      */
-    @JsonIgnore
+
     public int sourceLength() {
         return ListUtil.length(this.source);
     }
@@ -459,7 +459,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link SourceQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<SourceQuery> source() {
         return ListUtil.iterable(this.source);
     }
@@ -470,7 +470,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      * @param index Index of the source query to get.
      * @return {@link SourceQuery} at the input index.
      */
-    @JsonIgnore
+
     public SourceQuery getSource(final int index) {
         return ListUtil.get(this.source, index);
     }
@@ -501,7 +501,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      * @param quantity {@link QuantityQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public PifSystemQuery addQuantity(final List<QuantityQuery> quantity) {
         this.quantity = ListUtil.add(quantity, this.quantity);
         return this;
@@ -513,7 +513,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      * @param quantity {@link QuantityQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public PifSystemQuery addQuantity(final QuantityQuery quantity) {
         this.quantity = ListUtil.add(quantity, this.quantity);
         return this;
@@ -524,7 +524,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      *
      * @return Number of quantity queries.
      */
-    @JsonIgnore
+
     public int quantityLength() {
         return ListUtil.length(this.quantity);
     }
@@ -534,7 +534,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link QuantityQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<QuantityQuery> quantity() {
         return ListUtil.iterable(this.quantity);
     }
@@ -545,7 +545,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      * @param index Index of the quantity query to get.
      * @return {@link QuantityQuery} at the input index.
      */
-    @JsonIgnore
+
     public QuantityQuery getQuantity(final int index) {
         return ListUtil.get(this.quantity, index);
     }
@@ -576,7 +576,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      * @param chemicalFormula {@link ChemicalFieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public PifSystemQuery addChemicalFormula(final List<ChemicalFieldQuery> chemicalFormula) {
         this.chemicalFormula = ListUtil.add(chemicalFormula, this.chemicalFormula);
         return this;
@@ -588,7 +588,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      * @param chemicalFormula {@link ChemicalFieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public PifSystemQuery addChemicalFormula(final ChemicalFieldQuery chemicalFormula) {
         this.chemicalFormula = ListUtil.add(chemicalFormula, this.chemicalFormula);
         return this;
@@ -599,7 +599,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      *
      * @return Number of chemicalFormula queries.
      */
-    @JsonIgnore
+
     public int chemicalFormulaLength() {
         return ListUtil.length(this.chemicalFormula);
     }
@@ -609,7 +609,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link ChemicalFieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<ChemicalFieldQuery> chemicalFormula() {
         return ListUtil.iterable(this.chemicalFormula);
     }
@@ -620,7 +620,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      * @param index Index of the chemicalFormula query to get.
      * @return {@link ChemicalFieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public ChemicalFieldQuery getChemicalFormula(final int index) {
         return ListUtil.get(this.chemicalFormula, index);
     }
@@ -651,7 +651,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      * @param composition {@link CompositionQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public PifSystemQuery addComposition(final List<CompositionQuery> composition) {
         this.composition = ListUtil.add(composition, this.composition);
         return this;
@@ -663,7 +663,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      * @param composition {@link CompositionQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public PifSystemQuery addComposition(final CompositionQuery composition) {
         this.composition = ListUtil.add(composition, this.composition);
         return this;
@@ -674,7 +674,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      *
      * @return Number of composition queries.
      */
-    @JsonIgnore
+
     public int compositionLength() {
         return ListUtil.length(this.composition);
     }
@@ -684,7 +684,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link CompositionQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<CompositionQuery> composition() {
         return ListUtil.iterable(this.composition);
     }
@@ -695,7 +695,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      * @param index Index of the composition query to get.
      * @return {@link CompositionQuery} at the input index.
      */
-    @JsonIgnore
+
     public CompositionQuery getComposition(final int index) {
         return ListUtil.get(this.composition, index);
     }
@@ -726,7 +726,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      * @param properties {@link PropertyQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public PifSystemQuery addProperties(final List<PropertyQuery> properties) {
         this.properties = ListUtil.add(properties, this.properties);
         return this;
@@ -738,7 +738,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      * @param properties {@link PropertyQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public PifSystemQuery addProperties(final PropertyQuery properties) {
         this.properties = ListUtil.add(properties, this.properties);
         return this;
@@ -749,7 +749,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      *
      * @return Number of properties queries.
      */
-    @JsonIgnore
+
     public int propertiesLength() {
         return ListUtil.length(this.properties);
     }
@@ -759,7 +759,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link PropertyQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<PropertyQuery> properties() {
         return ListUtil.iterable(this.properties);
     }
@@ -770,7 +770,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      * @param index Index of the properties query to get.
      * @return {@link PropertyQuery} at the input index.
      */
-    @JsonIgnore
+
     public PropertyQuery getProperties(final int index) {
         return ListUtil.get(this.properties, index);
     }
@@ -801,7 +801,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      * @param preparation {@link ProcessStepQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public PifSystemQuery addPreparation(final List<ProcessStepQuery> preparation) {
         this.preparation = ListUtil.add(preparation, this.preparation);
         return this;
@@ -813,7 +813,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      * @param preparation {@link ProcessStepQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public PifSystemQuery addPreparation(final ProcessStepQuery preparation) {
         this.preparation = ListUtil.add(preparation, this.preparation);
         return this;
@@ -824,7 +824,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      *
      * @return Number of preparation queries.
      */
-    @JsonIgnore
+
     public int preparationLength() {
         return ListUtil.length(this.preparation);
     }
@@ -834,7 +834,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link ProcessStepQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<ProcessStepQuery> preparation() {
         return ListUtil.iterable(this.preparation);
     }
@@ -845,7 +845,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      * @param index Index of the preparation query to get.
      * @return {@link ProcessStepQuery} at the input index.
      */
-    @JsonIgnore
+
     public ProcessStepQuery getPreparation(final int index) {
         return ListUtil.get(this.preparation, index);
     }
@@ -876,7 +876,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      * @param references {@link ReferenceQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public PifSystemQuery addReferences(final List<ReferenceQuery> references) {
         this.references = ListUtil.add(references, this.references);
         return this;
@@ -888,7 +888,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      * @param references {@link ReferenceQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public PifSystemQuery addReferences(final ReferenceQuery references) {
         this.references = ListUtil.add(references, this.references);
         return this;
@@ -899,7 +899,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      *
      * @return Number of references queries.
      */
-    @JsonIgnore
+
     public int referencesLength() {
         return ListUtil.length(this.references);
     }
@@ -909,7 +909,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link ReferenceQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<ReferenceQuery> references() {
         return ListUtil.iterable(this.references);
     }
@@ -920,7 +920,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      * @param index Index of the references query to get.
      * @return {@link ReferenceQuery} at the input index.
      */
-    @JsonIgnore
+
     public ReferenceQuery getReferences(final int index) {
         return ListUtil.get(this.references, index);
     }
@@ -951,7 +951,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      * @param subSystems {@link PifSystemQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public PifSystemQuery addSubSystems(final List<PifSystemQuery> subSystems) {
         this.subSystems = ListUtil.add(subSystems, this.subSystems);
         return this;
@@ -963,7 +963,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      * @param subSystems {@link PifSystemQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public PifSystemQuery addSubSystems(final PifSystemQuery subSystems) {
         this.subSystems = ListUtil.add(subSystems, this.subSystems);
         return this;
@@ -974,7 +974,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      *
      * @return Number of subSystems queries.
      */
-    @JsonIgnore
+
     public int subSystemsLength() {
         return ListUtil.length(this.subSystems);
     }
@@ -984,7 +984,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link PifSystemQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<PifSystemQuery> subSystems() {
         return ListUtil.iterable(this.subSystems);
     }
@@ -995,7 +995,7 @@ public class PifSystemQuery extends BaseObjectQuery {
      * @param index Index of the subSystems query to get.
      * @return {@link PifSystemQuery} at the input index.
      */
-    @JsonIgnore
+
     public PifSystemQuery getSubSystems(final int index) {
         return ListUtil.get(this.subSystems, index);
     }

--- a/src/main/java/io/citrine/jcc/search/pif/query/PifSystemReturningQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/PifSystemReturningQuery.java
@@ -1,6 +1,5 @@
 package io.citrine.jcc.search.pif.query;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import io.citrine.jcc.search.core.query.BaseReturningQuery;
 import io.citrine.jcc.search.core.query.DataQuery;
@@ -68,14 +67,14 @@ public class PifSystemReturningQuery extends BaseReturningQuery {
     }
 
     @Override
-    @JsonIgnore
+
     public PifSystemReturningQuery addQuery(final List<DataQuery> query) {
         super.addQuery(query);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public PifSystemReturningQuery addQuery(final DataQuery query) {
         super.addQuery(query);
         return this;
@@ -159,7 +158,7 @@ public class PifSystemReturningQuery extends BaseReturningQuery {
      */
     @JsonSetter
     private void setExcludeDatasets(final List<Long> excludeDatasets) {  // Private since only Jackson should use it
-        if ((excludeDatasets != null)  && !excludeDatasets.isEmpty()) {
+        if ((excludeDatasets != null) && !excludeDatasets.isEmpty()) {
             final DatasetQuery datasetQuery = new DatasetQuery();
             excludeDatasets.forEach(i -> datasetQuery.addId(new Filter().setEqual(Long.toString(i))));
             this.addQuery(new DataQuery()

--- a/src/main/java/io/citrine/jcc/search/pif/query/chemical/ChemicalFieldQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/chemical/ChemicalFieldQuery.java
@@ -47,14 +47,14 @@ public class ChemicalFieldQuery extends BaseFieldQuery implements HasChemicalFil
     }
 
     @Override
-    @JsonIgnore
+
     public ChemicalFieldQuery addLength(final List<FieldQuery> length) {
         super.addLength(length);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public ChemicalFieldQuery addLength(final FieldQuery length) {
         super.addLength(length);
         return this;
@@ -67,14 +67,14 @@ public class ChemicalFieldQuery extends BaseFieldQuery implements HasChemicalFil
     }
 
     @Override
-    @JsonIgnore
+
     public ChemicalFieldQuery addOffset(final List<FieldQuery> offset) {
         super.addOffset(offset);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public ChemicalFieldQuery addOffset(final FieldQuery offset) {
         super.addOffset(offset);
         return this;
@@ -87,33 +87,33 @@ public class ChemicalFieldQuery extends BaseFieldQuery implements HasChemicalFil
     }
 
     @Override
-    @JsonIgnore
+
     public ChemicalFieldQuery addFilter(final List<ChemicalFilter> filter) {
         this.filter = ListUtil.add(filter, this.filter);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public ChemicalFieldQuery addFilter(final ChemicalFilter filter) {
         this.filter = ListUtil.add(filter, this.filter);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public int filterLength() {
         return ListUtil.length(this.filter);
     }
 
     @Override
-    @JsonIgnore
+
     public Iterable<ChemicalFilter> filter() {
         return ListUtil.iterable(this.filter);
     }
 
     @Override
-    @JsonIgnore
+
     public ChemicalFilter getFilter(final int index) {
         return ListUtil.get(this.filter, index);
     }

--- a/src/main/java/io/citrine/jcc/search/pif/query/chemical/ChemicalFilter.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/chemical/ChemicalFilter.java
@@ -32,33 +32,33 @@ public class ChemicalFilter implements HasLogic, HasChemicalFilter {
     }
 
     @Override
-    @JsonIgnore
+
     public ChemicalFilter addFilter(final List<ChemicalFilter> filter) {
         this.filter = ListUtil.add(filter, this.filter);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public ChemicalFilter addFilter(final ChemicalFilter filter) {
         this.filter = ListUtil.add(filter, this.filter);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public int filterLength() {
         return ListUtil.length(this.filter);
     }
 
     @Override
-    @JsonIgnore
+
     public Iterable<ChemicalFilter> filter() {
         return ListUtil.iterable(this.filter);
     }
 
     @Override
-    @JsonIgnore
+
     public ChemicalFilter getFilter(final int index) {
         return ListUtil.get(this.filter, index);
     }

--- a/src/main/java/io/citrine/jcc/search/pif/query/chemical/CompositionQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/chemical/CompositionQuery.java
@@ -46,14 +46,14 @@ public class CompositionQuery extends BaseObjectQuery {
     }
 
     @Override
-    @JsonIgnore
+
     public CompositionQuery addTags(final List<FieldQuery> tags) {
         super.addTags(tags);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public CompositionQuery addTags(final FieldQuery tags) {
         super.addTags(tags);
         return this;
@@ -66,14 +66,14 @@ public class CompositionQuery extends BaseObjectQuery {
     }
 
     @Override
-    @JsonIgnore
+
     public CompositionQuery addLength(final List<FieldQuery> length) {
         super.addLength(length);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public CompositionQuery addLength(final FieldQuery length) {
         super.addLength(length);
         return this;
@@ -86,14 +86,14 @@ public class CompositionQuery extends BaseObjectQuery {
     }
 
     @Override
-    @JsonIgnore
+
     public CompositionQuery addOffset(final List<FieldQuery> offset) {
         super.addOffset(offset);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public CompositionQuery addOffset(final FieldQuery offset) {
         super.addOffset(offset);
         return this;
@@ -116,7 +116,7 @@ public class CompositionQuery extends BaseObjectQuery {
      * @param element {@link ChemicalFieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public CompositionQuery addElement(final List<ChemicalFieldQuery> element) {
         this.element = ListUtil.add(element, this.element);
         return this;
@@ -128,7 +128,7 @@ public class CompositionQuery extends BaseObjectQuery {
      * @param element {@link ChemicalFieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public CompositionQuery addElement(final ChemicalFieldQuery element) {
         this.element = ListUtil.add(element, this.element);
         return this;
@@ -139,7 +139,7 @@ public class CompositionQuery extends BaseObjectQuery {
      *
      * @return Number of element queries.
      */
-    @JsonIgnore
+
     public int elementLength() {
         return ListUtil.length(this.element);
     }
@@ -149,7 +149,7 @@ public class CompositionQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link ChemicalFieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<ChemicalFieldQuery> element() {
         return ListUtil.iterable(this.element);
     }
@@ -160,7 +160,7 @@ public class CompositionQuery extends BaseObjectQuery {
      * @param index Index of the element query to get.
      * @return {@link ChemicalFieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public ChemicalFieldQuery getElement(final int index) {
         return ListUtil.get(this.element, index);
     }
@@ -191,7 +191,7 @@ public class CompositionQuery extends BaseObjectQuery {
      * @param actualWeightPercent {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public CompositionQuery addActualWeightPercent(final List<FieldQuery> actualWeightPercent) {
         this.actualWeightPercent = ListUtil.add(actualWeightPercent, this.actualWeightPercent);
         return this;
@@ -203,7 +203,7 @@ public class CompositionQuery extends BaseObjectQuery {
      * @param actualWeightPercent {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public CompositionQuery addActualWeightPercent(final FieldQuery actualWeightPercent) {
         this.actualWeightPercent = ListUtil.add(actualWeightPercent, this.actualWeightPercent);
         return this;
@@ -214,7 +214,7 @@ public class CompositionQuery extends BaseObjectQuery {
      *
      * @return Number of actualWeightPercent queries.
      */
-    @JsonIgnore
+
     public int actualWeightPercentLength() {
         return ListUtil.length(this.actualWeightPercent);
     }
@@ -224,7 +224,7 @@ public class CompositionQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> actualWeightPercent() {
         return ListUtil.iterable(this.actualWeightPercent);
     }
@@ -235,7 +235,7 @@ public class CompositionQuery extends BaseObjectQuery {
      * @param index Index of the actualWeightPercent query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getActualWeightPercent(final int index) {
         return ListUtil.get(this.actualWeightPercent, index);
     }
@@ -266,7 +266,7 @@ public class CompositionQuery extends BaseObjectQuery {
      * @param actualAtomicPercent {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public CompositionQuery addActualAtomicPercent(final List<FieldQuery> actualAtomicPercent) {
         this.actualAtomicPercent = ListUtil.add(actualAtomicPercent, this.actualAtomicPercent);
         return this;
@@ -278,7 +278,7 @@ public class CompositionQuery extends BaseObjectQuery {
      * @param actualAtomicPercent {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public CompositionQuery addActualAtomicPercent(final FieldQuery actualAtomicPercent) {
         this.actualAtomicPercent = ListUtil.add(actualAtomicPercent, this.actualAtomicPercent);
         return this;
@@ -289,7 +289,7 @@ public class CompositionQuery extends BaseObjectQuery {
      *
      * @return Number of actualAtomicPercent queries.
      */
-    @JsonIgnore
+
     public int actualAtomicPercentLength() {
         return ListUtil.length(this.actualAtomicPercent);
     }
@@ -299,7 +299,7 @@ public class CompositionQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> actualAtomicPercent() {
         return ListUtil.iterable(this.actualAtomicPercent);
     }
@@ -310,7 +310,7 @@ public class CompositionQuery extends BaseObjectQuery {
      * @param index Index of the actualAtomicPercent query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getActualAtomicPercent(final int index) {
         return ListUtil.get(this.actualAtomicPercent, index);
     }
@@ -341,7 +341,7 @@ public class CompositionQuery extends BaseObjectQuery {
      * @param idealWeightPercent {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public CompositionQuery addIdealWeightPercent(final List<FieldQuery> idealWeightPercent) {
         this.idealWeightPercent = ListUtil.add(idealWeightPercent, this.idealWeightPercent);
         return this;
@@ -353,7 +353,7 @@ public class CompositionQuery extends BaseObjectQuery {
      * @param idealWeightPercent {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public CompositionQuery addIdealWeightPercent(final FieldQuery idealWeightPercent) {
         this.idealWeightPercent = ListUtil.add(idealWeightPercent, this.idealWeightPercent);
         return this;
@@ -364,7 +364,7 @@ public class CompositionQuery extends BaseObjectQuery {
      *
      * @return Number of idealWeightPercent queries.
      */
-    @JsonIgnore
+
     public int idealWeightPercentLength() {
         return ListUtil.length(this.idealWeightPercent);
     }
@@ -374,7 +374,7 @@ public class CompositionQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> idealWeightPercent() {
         return ListUtil.iterable(this.idealWeightPercent);
     }
@@ -385,7 +385,7 @@ public class CompositionQuery extends BaseObjectQuery {
      * @param index Index of the idealWeightPercent query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getIdealWeightPercent(final int index) {
         return ListUtil.get(this.idealWeightPercent, index);
     }
@@ -416,7 +416,7 @@ public class CompositionQuery extends BaseObjectQuery {
      * @param idealAtomicPercent {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public CompositionQuery addIdealAtomicPercent(final List<FieldQuery> idealAtomicPercent) {
         this.idealAtomicPercent = ListUtil.add(idealAtomicPercent, this.idealAtomicPercent);
         return this;
@@ -428,7 +428,7 @@ public class CompositionQuery extends BaseObjectQuery {
      * @param idealAtomicPercent {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public CompositionQuery addIdealAtomicPercent(final FieldQuery idealAtomicPercent) {
         this.idealAtomicPercent = ListUtil.add(idealAtomicPercent, this.idealAtomicPercent);
         return this;
@@ -439,7 +439,7 @@ public class CompositionQuery extends BaseObjectQuery {
      *
      * @return Number of idealAtomicPercent queries.
      */
-    @JsonIgnore
+
     public int idealAtomicPercentLength() {
         return ListUtil.length(this.idealAtomicPercent);
     }
@@ -449,7 +449,7 @@ public class CompositionQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> idealAtomicPercent() {
         return ListUtil.iterable(this.idealAtomicPercent);
     }
@@ -460,7 +460,7 @@ public class CompositionQuery extends BaseObjectQuery {
      * @param index Index of the idealAtomicPercent query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getIdealAtomicPercent(final int index) {
         return ListUtil.get(this.idealAtomicPercent, index);
     }

--- a/src/main/java/io/citrine/jcc/search/pif/query/chemical/HasChemicalFilter.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/chemical/HasChemicalFilter.java
@@ -25,7 +25,7 @@ public interface HasChemicalFilter {
      * @param filter List of {@link ChemicalFilter} objects to save.
      * @return This object.
      */
-    @JsonIgnore
+
     HasChemicalFilter addFilter(final List<ChemicalFilter> filter);
 
     /**
@@ -34,7 +34,7 @@ public interface HasChemicalFilter {
      * @param filter {@link ChemicalFilter} object to add.
      * @return This object.
      */
-    @JsonIgnore
+
     HasChemicalFilter addFilter(final ChemicalFilter filter);
 
     /**
@@ -42,7 +42,7 @@ public interface HasChemicalFilter {
      *
      * @return Number of filters.
      */
-    @JsonIgnore
+
     int filterLength();
 
     /**
@@ -50,7 +50,7 @@ public interface HasChemicalFilter {
      *
      * @return Iterable of {@link ChemicalFilter} objects.
      */
-    @JsonIgnore
+
     Iterable<ChemicalFilter> filter();
 
     /**
@@ -59,7 +59,7 @@ public interface HasChemicalFilter {
      * @param index Index of the filter to get.
      * @return Filter at the input index.
      */
-    @JsonIgnore
+
     ChemicalFilter getFilter(final int index);
 
     /**

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/BaseFieldQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/BaseFieldQuery.java
@@ -104,7 +104,7 @@ public abstract class BaseFieldQuery implements HasLogic {
      * @param length {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public BaseFieldQuery addLength(final List<FieldQuery> length) {
         this.length = ListUtil.add(length, this.length);
         return this;
@@ -116,7 +116,7 @@ public abstract class BaseFieldQuery implements HasLogic {
      * @param length {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public BaseFieldQuery addLength(final FieldQuery length) {
         this.length = ListUtil.add(length, this.length);
         return this;
@@ -127,7 +127,7 @@ public abstract class BaseFieldQuery implements HasLogic {
      * 
      * @return Number of length queries.
      */
-    @JsonIgnore
+
     public int lengthLength() {
         return ListUtil.length(this.length);
     }
@@ -137,7 +137,7 @@ public abstract class BaseFieldQuery implements HasLogic {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> length() {
         return ListUtil.iterable(this.length);
     }
@@ -148,7 +148,7 @@ public abstract class BaseFieldQuery implements HasLogic {
      * @param index Index of the length query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getLength(final int index) {
         return ListUtil.get(this.length, index);
     }
@@ -179,7 +179,7 @@ public abstract class BaseFieldQuery implements HasLogic {
      * @param offset {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public BaseFieldQuery addOffset(final List<FieldQuery> offset) {
         this.offset = ListUtil.add(offset, this.offset);
         return this;
@@ -191,7 +191,7 @@ public abstract class BaseFieldQuery implements HasLogic {
      * @param offset {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public BaseFieldQuery addOffset(final FieldQuery offset) {
         this.offset = ListUtil.add(offset, this.offset);
         return this;
@@ -202,7 +202,7 @@ public abstract class BaseFieldQuery implements HasLogic {
      *
      * @return Number of offset queries.
      */
-    @JsonIgnore
+
     public int offsetLength() {
         return ListUtil.length(this.offset);
     }
@@ -212,7 +212,7 @@ public abstract class BaseFieldQuery implements HasLogic {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> offset() {
         return ListUtil.iterable(this.offset);
     }
@@ -223,7 +223,7 @@ public abstract class BaseFieldQuery implements HasLogic {
      * @param index Index of the offset query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getOffset(final int index) {
         return ListUtil.get(this.offset, index);
     }

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/BaseObjectQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/BaseObjectQuery.java
@@ -103,7 +103,7 @@ public abstract class BaseObjectQuery implements HasLogic {
      * @param tags {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public BaseObjectQuery addTags(final List<FieldQuery> tags) {
         this.tags = ListUtil.add(tags, this.tags);
         return this;
@@ -115,7 +115,7 @@ public abstract class BaseObjectQuery implements HasLogic {
      * @param tags {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public BaseObjectQuery addTags(final FieldQuery tags) {
         this.tags = ListUtil.add(tags, this.tags);
         return this;
@@ -126,7 +126,7 @@ public abstract class BaseObjectQuery implements HasLogic {
      *
      * @return Number of tags queries.
      */
-    @JsonIgnore
+
     public int tagsLength() {
         return ListUtil.length(this.tags);
     }
@@ -136,7 +136,7 @@ public abstract class BaseObjectQuery implements HasLogic {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> tags() {
         return ListUtil.iterable(this.tags);
     }
@@ -147,7 +147,7 @@ public abstract class BaseObjectQuery implements HasLogic {
      * @param index Index of the tags query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getTags(final int index) {
         return ListUtil.get(this.tags, index);
     }
@@ -178,7 +178,7 @@ public abstract class BaseObjectQuery implements HasLogic {
      * @param length {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public BaseObjectQuery addLength(final List<FieldQuery> length) {
         this.length = ListUtil.add(length, this.length);
         return this;
@@ -190,7 +190,7 @@ public abstract class BaseObjectQuery implements HasLogic {
      * @param length {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public BaseObjectQuery addLength(final FieldQuery length) {
         this.length = ListUtil.add(length, this.length);
         return this;
@@ -201,7 +201,7 @@ public abstract class BaseObjectQuery implements HasLogic {
      *
      * @return Number of length queries.
      */
-    @JsonIgnore
+
     public int lengthLength() {
         return ListUtil.length(this.length);
     }
@@ -211,7 +211,7 @@ public abstract class BaseObjectQuery implements HasLogic {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> length() {
         return ListUtil.iterable(this.length);
     }
@@ -222,7 +222,7 @@ public abstract class BaseObjectQuery implements HasLogic {
      * @param index Index of the length query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getLength(final int index) {
         return ListUtil.get(this.length, index);
     }
@@ -253,7 +253,7 @@ public abstract class BaseObjectQuery implements HasLogic {
      * @param offset {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public BaseObjectQuery addOffset(final List<FieldQuery> offset) {
         this.offset = ListUtil.add(offset, this.offset);
         return this;
@@ -265,7 +265,7 @@ public abstract class BaseObjectQuery implements HasLogic {
      * @param offset {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public BaseObjectQuery addOffset(final FieldQuery offset) {
         this.offset = ListUtil.add(offset, this.offset);
         return this;
@@ -276,7 +276,7 @@ public abstract class BaseObjectQuery implements HasLogic {
      *
      * @return Number of offset queries.
      */
-    @JsonIgnore
+
     public int offsetLength() {
         return ListUtil.length(this.offset);
     }
@@ -286,7 +286,7 @@ public abstract class BaseObjectQuery implements HasLogic {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> offset() {
         return ListUtil.iterable(this.offset);
     }
@@ -297,7 +297,7 @@ public abstract class BaseObjectQuery implements HasLogic {
      * @param index Index of the offset query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getOffset(final int index) {
         return ListUtil.get(this.offset, index);
     }

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/ClassificationQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/ClassificationQuery.java
@@ -44,14 +44,14 @@ public class ClassificationQuery extends BaseObjectQuery {
     }
 
     @Override
-    @JsonIgnore
+
     public ClassificationQuery addTags(final List<FieldQuery> tags) {
         super.addTags(tags);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public ClassificationQuery addTags(final FieldQuery tags) {
         super.addTags(tags);
         return this;
@@ -64,14 +64,14 @@ public class ClassificationQuery extends BaseObjectQuery {
     }
 
     @Override
-    @JsonIgnore
+
     public ClassificationQuery addLength(final List<FieldQuery> length) {
         super.addLength(length);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public ClassificationQuery addLength(final FieldQuery length) {
         super.addLength(length);
         return this;
@@ -84,14 +84,14 @@ public class ClassificationQuery extends BaseObjectQuery {
     }
 
     @Override
-    @JsonIgnore
+
     public ClassificationQuery addOffset(final List<FieldQuery> offset) {
         super.addOffset(offset);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public ClassificationQuery addOffset(final FieldQuery offset) {
         super.addOffset(offset);
         return this;
@@ -114,7 +114,7 @@ public class ClassificationQuery extends BaseObjectQuery {
      * @param name {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ClassificationQuery addName(final List<FieldQuery> name) {
         this.name = ListUtil.add(name, this.name);
         return this;
@@ -126,7 +126,7 @@ public class ClassificationQuery extends BaseObjectQuery {
      * @param name {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ClassificationQuery addName(final FieldQuery name) {
         this.name = ListUtil.add(name, this.name);
         return this;
@@ -137,7 +137,7 @@ public class ClassificationQuery extends BaseObjectQuery {
      *
      * @return Number of name queries.
      */
-    @JsonIgnore
+
     public int nameLength() {
         return ListUtil.length(this.name);
     }
@@ -147,7 +147,7 @@ public class ClassificationQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> name() {
         return ListUtil.iterable(this.name);
     }
@@ -158,7 +158,7 @@ public class ClassificationQuery extends BaseObjectQuery {
      * @param index Index of the name query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getName(final int index) {
         return ListUtil.get(this.name, index);
     }
@@ -189,7 +189,7 @@ public class ClassificationQuery extends BaseObjectQuery {
      * @param value {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ClassificationQuery addValue(final List<FieldQuery> value) {
         this.value = ListUtil.add(value, this.value);
         return this;
@@ -201,7 +201,7 @@ public class ClassificationQuery extends BaseObjectQuery {
      * @param value {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ClassificationQuery addValue(final FieldQuery value) {
         this.value = ListUtil.add(value, this.value);
         return this;
@@ -212,7 +212,7 @@ public class ClassificationQuery extends BaseObjectQuery {
      *
      * @return Number of value queries.
      */
-    @JsonIgnore
+
     public int valueLength() {
         return ListUtil.length(this.value);
     }
@@ -222,7 +222,7 @@ public class ClassificationQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> value() {
         return ListUtil.iterable(this.value);
     }
@@ -233,7 +233,7 @@ public class ClassificationQuery extends BaseObjectQuery {
      * @param index Index of the value query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getValue(final int index) {
         return ListUtil.get(this.value, index);
     }

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/DisplayItemQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/DisplayItemQuery.java
@@ -44,14 +44,14 @@ public class DisplayItemQuery extends BaseObjectQuery {
     }
 
     @Override
-    @JsonIgnore
+
     public DisplayItemQuery addTags(final List<FieldQuery> tags) {
         super.addTags(tags);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public DisplayItemQuery addTags(final FieldQuery tags) {
         super.addTags(tags);
         return this;
@@ -64,14 +64,14 @@ public class DisplayItemQuery extends BaseObjectQuery {
     }
 
     @Override
-    @JsonIgnore
+
     public DisplayItemQuery addLength(final List<FieldQuery> length) {
         super.addLength(length);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public DisplayItemQuery addLength(final FieldQuery length) {
         super.addLength(length);
         return this;
@@ -84,14 +84,14 @@ public class DisplayItemQuery extends BaseObjectQuery {
     }
 
     @Override
-    @JsonIgnore
+
     public DisplayItemQuery addOffset(final List<FieldQuery> offset) {
         super.addOffset(offset);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public DisplayItemQuery addOffset(final FieldQuery offset) {
         super.addOffset(offset);
         return this;
@@ -114,7 +114,7 @@ public class DisplayItemQuery extends BaseObjectQuery {
      * @param number {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public DisplayItemQuery addNumber(final List<FieldQuery> number) {
         this.number = ListUtil.add(number, this.number);
         return this;
@@ -126,7 +126,7 @@ public class DisplayItemQuery extends BaseObjectQuery {
      * @param number {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public DisplayItemQuery addNumber(final FieldQuery number) {
         this.number = ListUtil.add(number, this.number);
         return this;
@@ -137,7 +137,7 @@ public class DisplayItemQuery extends BaseObjectQuery {
      *
      * @return Number of number queries.
      */
-    @JsonIgnore
+
     public int numberLength() {
         return ListUtil.length(this.number);
     }
@@ -147,7 +147,7 @@ public class DisplayItemQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> number() {
         return ListUtil.iterable(this.number);
     }
@@ -158,7 +158,7 @@ public class DisplayItemQuery extends BaseObjectQuery {
      * @param index Index of the number query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getNumber(final int index) {
         return ListUtil.get(this.number, index);
     }
@@ -189,7 +189,7 @@ public class DisplayItemQuery extends BaseObjectQuery {
      * @param title {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public DisplayItemQuery addTitle(final List<FieldQuery> title) {
         this.title = ListUtil.add(title, this.title);
         return this;
@@ -201,7 +201,7 @@ public class DisplayItemQuery extends BaseObjectQuery {
      * @param title {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public DisplayItemQuery addTitle(final FieldQuery title) {
         this.title = ListUtil.add(title, this.title);
         return this;
@@ -212,7 +212,7 @@ public class DisplayItemQuery extends BaseObjectQuery {
      *
      * @return Title of title queries.
      */
-    @JsonIgnore
+
     public int titleLength() {
         return ListUtil.length(this.title);
     }
@@ -222,7 +222,7 @@ public class DisplayItemQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> title() {
         return ListUtil.iterable(this.title);
     }
@@ -233,7 +233,7 @@ public class DisplayItemQuery extends BaseObjectQuery {
      * @param index Index of the title query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getTitle(final int index) {
         return ListUtil.get(this.title, index);
     }
@@ -264,7 +264,7 @@ public class DisplayItemQuery extends BaseObjectQuery {
      * @param caption {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public DisplayItemQuery addCaption(final List<FieldQuery> caption) {
         this.caption = ListUtil.add(caption, this.caption);
         return this;
@@ -276,7 +276,7 @@ public class DisplayItemQuery extends BaseObjectQuery {
      * @param caption {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public DisplayItemQuery addCaption(final FieldQuery caption) {
         this.caption = ListUtil.add(caption, this.caption);
         return this;
@@ -287,7 +287,7 @@ public class DisplayItemQuery extends BaseObjectQuery {
      *
      * @return Caption of caption queries.
      */
-    @JsonIgnore
+
     public int captionLength() {
         return ListUtil.length(this.caption);
     }
@@ -297,7 +297,7 @@ public class DisplayItemQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> caption() {
         return ListUtil.iterable(this.caption);
     }
@@ -308,7 +308,7 @@ public class DisplayItemQuery extends BaseObjectQuery {
      * @param index Index of the caption query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getCaption(final int index) {
         return ListUtil.get(this.caption, index);
     }

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/FieldQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/FieldQuery.java
@@ -47,14 +47,14 @@ public class FieldQuery extends BaseFieldQuery implements HasFilter {
     }
 
     @Override
-    @JsonIgnore
+
     public FieldQuery addLength(final List<FieldQuery> length) {
         super.addLength(length);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public FieldQuery addLength(final FieldQuery length) {
         super.addLength(length);
         return this;
@@ -67,14 +67,14 @@ public class FieldQuery extends BaseFieldQuery implements HasFilter {
     }
 
     @Override
-    @JsonIgnore
+
     public FieldQuery addOffset(final List<FieldQuery> offset) {
         super.addOffset(offset);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public FieldQuery addOffset(final FieldQuery offset) {
         super.addOffset(offset);
         return this;
@@ -87,33 +87,33 @@ public class FieldQuery extends BaseFieldQuery implements HasFilter {
     }
 
     @Override
-    @JsonIgnore
+
     public FieldQuery addFilter(final List<Filter> filter) {
         this.filter = ListUtil.add(filter, this.filter);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public FieldQuery addFilter(final Filter filter) {
         this.filter = ListUtil.add(filter, this.filter);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public int filterLength() {
         return ListUtil.length(this.filter);
     }
 
     @Override
-    @JsonIgnore
+
     public Iterable<Filter> filter() {
         return ListUtil.iterable(this.filter);
     }
 
     @Override
-    @JsonIgnore
+
     public Filter getFilter(final int index) {
         return ListUtil.get(this.filter, index);
     }

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/FileReferenceQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/FileReferenceQuery.java
@@ -44,14 +44,14 @@ public class FileReferenceQuery extends BaseObjectQuery {
     }
 
     @Override
-    @JsonIgnore
+
     public FileReferenceQuery addTags(final List<FieldQuery> tags) {
         super.addTags(tags);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public FileReferenceQuery addTags(final FieldQuery tags) {
         super.addTags(tags);
         return this;
@@ -64,14 +64,14 @@ public class FileReferenceQuery extends BaseObjectQuery {
     }
 
     @Override
-    @JsonIgnore
+
     public FileReferenceQuery addLength(final List<FieldQuery> length) {
         super.addLength(length);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public FileReferenceQuery addLength(final FieldQuery length) {
         super.addLength(length);
         return this;
@@ -84,14 +84,14 @@ public class FileReferenceQuery extends BaseObjectQuery {
     }
 
     @Override
-    @JsonIgnore
+
     public FileReferenceQuery addOffset(final List<FieldQuery> offset) {
         super.addOffset(offset);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public FileReferenceQuery addOffset(final FieldQuery offset) {
         super.addOffset(offset);
         return this;
@@ -114,7 +114,7 @@ public class FileReferenceQuery extends BaseObjectQuery {
      * @param relativePath {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public FileReferenceQuery addRelativePath(final List<FieldQuery> relativePath) {
         this.relativePath = ListUtil.add(relativePath, this.relativePath);
         return this;
@@ -126,7 +126,7 @@ public class FileReferenceQuery extends BaseObjectQuery {
      * @param relativePath {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public FileReferenceQuery addRelativePath(final FieldQuery relativePath) {
         this.relativePath = ListUtil.add(relativePath, this.relativePath);
         return this;
@@ -137,7 +137,7 @@ public class FileReferenceQuery extends BaseObjectQuery {
      *
      * @return Number of relativePath queries.
      */
-    @JsonIgnore
+
     public int relativePathLength() {
         return ListUtil.length(this.relativePath);
     }
@@ -147,7 +147,7 @@ public class FileReferenceQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> relativePath() {
         return ListUtil.iterable(this.relativePath);
     }
@@ -158,7 +158,7 @@ public class FileReferenceQuery extends BaseObjectQuery {
      * @param index Index of the relativePath query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getRelativePath(final int index) {
         return ListUtil.get(this.relativePath, index);
     }
@@ -189,7 +189,7 @@ public class FileReferenceQuery extends BaseObjectQuery {
      * @param mimeType {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public FileReferenceQuery addMimeType(final List<FieldQuery> mimeType) {
         this.mimeType = ListUtil.add(mimeType, this.mimeType);
         return this;
@@ -201,7 +201,7 @@ public class FileReferenceQuery extends BaseObjectQuery {
      * @param mimeType {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public FileReferenceQuery addMimeType(final FieldQuery mimeType) {
         this.mimeType = ListUtil.add(mimeType, this.mimeType);
         return this;
@@ -212,7 +212,7 @@ public class FileReferenceQuery extends BaseObjectQuery {
      *
      * @return Number of mimeType queries.
      */
-    @JsonIgnore
+
     public int mimeTypeLength() {
         return ListUtil.length(this.mimeType);
     }
@@ -222,7 +222,7 @@ public class FileReferenceQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> mimeType() {
         return ListUtil.iterable(this.mimeType);
     }
@@ -233,7 +233,7 @@ public class FileReferenceQuery extends BaseObjectQuery {
      * @param index Index of the mimeType query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getMimeType(final int index) {
         return ListUtil.get(this.mimeType, index);
     }
@@ -264,7 +264,7 @@ public class FileReferenceQuery extends BaseObjectQuery {
      * @param sha256 {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public FileReferenceQuery addSha256(final List<FieldQuery> sha256) {
         this.sha256 = ListUtil.add(sha256, this.sha256);
         return this;
@@ -276,7 +276,7 @@ public class FileReferenceQuery extends BaseObjectQuery {
      * @param sha256 {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public FileReferenceQuery addSha256(final FieldQuery sha256) {
         this.sha256 = ListUtil.add(sha256, this.sha256);
         return this;
@@ -287,7 +287,7 @@ public class FileReferenceQuery extends BaseObjectQuery {
      *
      * @return Number of sha256 queries.
      */
-    @JsonIgnore
+
     public int sha256Length() {
         return ListUtil.length(this.sha256);
     }
@@ -297,7 +297,7 @@ public class FileReferenceQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> sha256() {
         return ListUtil.iterable(this.sha256);
     }
@@ -308,7 +308,7 @@ public class FileReferenceQuery extends BaseObjectQuery {
      * @param index Index of the sha256 query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getSha256(final int index) {
         return ListUtil.get(this.sha256, index);
     }
@@ -339,7 +339,7 @@ public class FileReferenceQuery extends BaseObjectQuery {
      * @param md5 {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public FileReferenceQuery addMd5(final List<FieldQuery> md5) {
         this.md5 = ListUtil.add(md5, this.md5);
         return this;
@@ -351,7 +351,7 @@ public class FileReferenceQuery extends BaseObjectQuery {
      * @param md5 {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public FileReferenceQuery addMd5(final FieldQuery md5) {
         this.md5 = ListUtil.add(md5, this.md5);
         return this;
@@ -362,7 +362,7 @@ public class FileReferenceQuery extends BaseObjectQuery {
      *
      * @return Number of md5 queries.
      */
-    @JsonIgnore
+
     public int md5Length() {
         return ListUtil.length(this.md5);
     }
@@ -372,7 +372,7 @@ public class FileReferenceQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> md5() {
         return ListUtil.iterable(this.md5);
     }
@@ -383,7 +383,7 @@ public class FileReferenceQuery extends BaseObjectQuery {
      * @param index Index of the md5 query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getMd5(final int index) {
         return ListUtil.get(this.md5, index);
     }

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/IdQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/IdQuery.java
@@ -44,14 +44,14 @@ public class IdQuery extends BaseObjectQuery {
     }
 
     @Override
-    @JsonIgnore
+
     public IdQuery addTags(final List<FieldQuery> tags) {
         super.addTags(tags);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public IdQuery addTags(final FieldQuery tags) {
         super.addTags(tags);
         return this;
@@ -64,14 +64,14 @@ public class IdQuery extends BaseObjectQuery {
     }
 
     @Override
-    @JsonIgnore
+
     public IdQuery addLength(final List<FieldQuery> length) {
         super.addLength(length);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public IdQuery addLength(final FieldQuery length) {
         super.addLength(length);
         return this;
@@ -84,14 +84,14 @@ public class IdQuery extends BaseObjectQuery {
     }
 
     @Override
-    @JsonIgnore
+
     public IdQuery addOffset(final List<FieldQuery> offset) {
         super.addOffset(offset);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public IdQuery addOffset(final FieldQuery offset) {
         super.addOffset(offset);
         return this;
@@ -114,7 +114,7 @@ public class IdQuery extends BaseObjectQuery {
      * @param name {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public IdQuery addName(final List<FieldQuery> name) {
         this.name = ListUtil.add(name, this.name);
         return this;
@@ -126,7 +126,7 @@ public class IdQuery extends BaseObjectQuery {
      * @param name {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public IdQuery addName(final FieldQuery name) {
         this.name = ListUtil.add(name, this.name);
         return this;
@@ -137,7 +137,7 @@ public class IdQuery extends BaseObjectQuery {
      *
      * @return Number of name queries.
      */
-    @JsonIgnore
+
     public int nameLength() {
         return ListUtil.length(this.name);
     }
@@ -147,7 +147,7 @@ public class IdQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> name() {
         return ListUtil.iterable(this.name);
     }
@@ -158,7 +158,7 @@ public class IdQuery extends BaseObjectQuery {
      * @param index Index of the name query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getName(final int index) {
         return ListUtil.get(this.name, index);
     }
@@ -189,7 +189,7 @@ public class IdQuery extends BaseObjectQuery {
      * @param value {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public IdQuery addValue(final List<FieldQuery> value) {
         this.value = ListUtil.add(value, this.value);
         return this;
@@ -201,7 +201,7 @@ public class IdQuery extends BaseObjectQuery {
      * @param value {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public IdQuery addValue(final FieldQuery value) {
         this.value = ListUtil.add(value, this.value);
         return this;
@@ -212,7 +212,7 @@ public class IdQuery extends BaseObjectQuery {
      *
      * @return Number of value queries.
      */
-    @JsonIgnore
+
     public int valueLength() {
         return ListUtil.length(this.value);
     }
@@ -222,7 +222,7 @@ public class IdQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> value() {
         return ListUtil.iterable(this.value);
     }
@@ -233,7 +233,7 @@ public class IdQuery extends BaseObjectQuery {
      * @param index Index of the value query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getValue(final int index) {
         return ListUtil.get(this.value, index);
     }

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/NameQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/NameQuery.java
@@ -44,14 +44,14 @@ public class NameQuery extends BaseObjectQuery {
     }
 
     @Override
-    @JsonIgnore
+
     public NameQuery addTags(final List<FieldQuery> tags) {
         super.addTags(tags);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public NameQuery addTags(final FieldQuery tags) {
         super.addTags(tags);
         return this;
@@ -64,14 +64,14 @@ public class NameQuery extends BaseObjectQuery {
     }
 
     @Override
-    @JsonIgnore
+
     public NameQuery addLength(final List<FieldQuery> length) {
         super.addLength(length);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public NameQuery addLength(final FieldQuery length) {
         super.addLength(length);
         return this;
@@ -84,14 +84,14 @@ public class NameQuery extends BaseObjectQuery {
     }
 
     @Override
-    @JsonIgnore
+
     public NameQuery addOffset(final List<FieldQuery> offset) {
         super.addOffset(offset);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public NameQuery addOffset(final FieldQuery offset) {
         super.addOffset(offset);
         return this;
@@ -114,7 +114,7 @@ public class NameQuery extends BaseObjectQuery {
      * @param given {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public NameQuery addGiven(final List<FieldQuery> given) {
         this.given = ListUtil.add(given, this.given);
         return this;
@@ -126,7 +126,7 @@ public class NameQuery extends BaseObjectQuery {
      * @param given {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public NameQuery addGiven(final FieldQuery given) {
         this.given = ListUtil.add(given, this.given);
         return this;
@@ -137,7 +137,7 @@ public class NameQuery extends BaseObjectQuery {
      *
      * @return Number of given queries.
      */
-    @JsonIgnore
+
     public int givenLength() {
         return ListUtil.length(this.given);
     }
@@ -147,7 +147,7 @@ public class NameQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> given() {
         return ListUtil.iterable(this.given);
     }
@@ -158,7 +158,7 @@ public class NameQuery extends BaseObjectQuery {
      * @param index Index of the given query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getGiven(final int index) {
         return ListUtil.get(this.given, index);
     }
@@ -189,7 +189,7 @@ public class NameQuery extends BaseObjectQuery {
      * @param family {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public NameQuery addFamily(final List<FieldQuery> family) {
         this.family = ListUtil.add(family, this.family);
         return this;
@@ -201,7 +201,7 @@ public class NameQuery extends BaseObjectQuery {
      * @param family {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public NameQuery addFamily(final FieldQuery family) {
         this.family = ListUtil.add(family, this.family);
         return this;
@@ -212,7 +212,7 @@ public class NameQuery extends BaseObjectQuery {
      *
      * @return Number of family queries.
      */
-    @JsonIgnore
+
     public int familyLength() {
         return ListUtil.length(this.family);
     }
@@ -222,7 +222,7 @@ public class NameQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> family() {
         return ListUtil.iterable(this.family);
     }
@@ -233,7 +233,7 @@ public class NameQuery extends BaseObjectQuery {
      * @param index Index of the family query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getFamily(final int index) {
         return ListUtil.get(this.family, index);
     }
@@ -264,7 +264,7 @@ public class NameQuery extends BaseObjectQuery {
      * @param title {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public NameQuery addTitle(final List<FieldQuery> title) {
         this.title = ListUtil.add(title, this.title);
         return this;
@@ -276,7 +276,7 @@ public class NameQuery extends BaseObjectQuery {
      * @param title {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public NameQuery addTitle(final FieldQuery title) {
         this.title = ListUtil.add(title, this.title);
         return this;
@@ -287,7 +287,7 @@ public class NameQuery extends BaseObjectQuery {
      *
      * @return Number of title queries.
      */
-    @JsonIgnore
+
     public int titleLength() {
         return ListUtil.length(this.title);
     }
@@ -297,7 +297,7 @@ public class NameQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> title() {
         return ListUtil.iterable(this.title);
     }
@@ -308,7 +308,7 @@ public class NameQuery extends BaseObjectQuery {
      * @param index Index of the title query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getTitle(final int index) {
         return ListUtil.get(this.title, index);
     }
@@ -339,7 +339,7 @@ public class NameQuery extends BaseObjectQuery {
      * @param suffix {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public NameQuery addSuffix(final List<FieldQuery> suffix) {
         this.suffix = ListUtil.add(suffix, this.suffix);
         return this;
@@ -351,7 +351,7 @@ public class NameQuery extends BaseObjectQuery {
      * @param suffix {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public NameQuery addSuffix(final FieldQuery suffix) {
         this.suffix = ListUtil.add(suffix, this.suffix);
         return this;
@@ -362,7 +362,7 @@ public class NameQuery extends BaseObjectQuery {
      *
      * @return Number of suffix queries.
      */
-    @JsonIgnore
+
     public int suffixLength() {
         return ListUtil.length(this.suffix);
     }
@@ -372,7 +372,7 @@ public class NameQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> suffix() {
         return ListUtil.iterable(this.suffix);
     }
@@ -383,7 +383,7 @@ public class NameQuery extends BaseObjectQuery {
      * @param index Index of the suffix query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getSuffix(final int index) {
         return ListUtil.get(this.suffix, index);
     }

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/PagesQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/PagesQuery.java
@@ -45,14 +45,14 @@ public class PagesQuery extends BaseObjectQuery {
     }
 
     @Override
-    @JsonIgnore
+
     public PagesQuery addTags(final List<FieldQuery> tags) {
         super.addTags(tags);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public PagesQuery addTags(final FieldQuery tags) {
         super.addTags(tags);
         return this;
@@ -65,14 +65,14 @@ public class PagesQuery extends BaseObjectQuery {
     }
 
     @Override
-    @JsonIgnore
+
     public PagesQuery addLength(final List<FieldQuery> length) {
         super.addLength(length);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public PagesQuery addLength(final FieldQuery length) {
         super.addLength(length);
         return this;
@@ -85,14 +85,14 @@ public class PagesQuery extends BaseObjectQuery {
     }
 
     @Override
-    @JsonIgnore
+
     public PagesQuery addOffset(final List<FieldQuery> offset) {
         super.addOffset(offset);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public PagesQuery addOffset(final FieldQuery offset) {
         super.addOffset(offset);
         return this;
@@ -115,7 +115,7 @@ public class PagesQuery extends BaseObjectQuery {
      * @param start {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public PagesQuery addStart(final List<FieldQuery> start) {
         this.start = ListUtil.add(start, this.start);
         return this;
@@ -127,7 +127,7 @@ public class PagesQuery extends BaseObjectQuery {
      * @param start {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public PagesQuery addStart(final FieldQuery start) {
         this.start = ListUtil.add(start, this.start);
         return this;
@@ -138,7 +138,7 @@ public class PagesQuery extends BaseObjectQuery {
      *
      * @return Number of start queries.
      */
-    @JsonIgnore
+
     public int startLength() {
         return ListUtil.length(this.start);
     }
@@ -148,7 +148,7 @@ public class PagesQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> start() {
         return ListUtil.iterable(this.start);
     }
@@ -159,7 +159,7 @@ public class PagesQuery extends BaseObjectQuery {
      * @param index Index of the start query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getStart(final int index) {
         return ListUtil.get(this.start, index);
     }
@@ -190,7 +190,7 @@ public class PagesQuery extends BaseObjectQuery {
      * @param end {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public PagesQuery addEnd(final List<FieldQuery> end) {
         this.end = ListUtil.add(end, this.end);
         return this;
@@ -202,7 +202,7 @@ public class PagesQuery extends BaseObjectQuery {
      * @param end {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public PagesQuery addEnd(final FieldQuery end) {
         this.end = ListUtil.add(end, this.end);
         return this;
@@ -213,7 +213,7 @@ public class PagesQuery extends BaseObjectQuery {
      *
      * @return Number of end queries.
      */
-    @JsonIgnore
+
     public int endLength() {
         return ListUtil.length(this.end);
     }
@@ -223,7 +223,7 @@ public class PagesQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> end() {
         return ListUtil.iterable(this.end);
     }
@@ -234,7 +234,7 @@ public class PagesQuery extends BaseObjectQuery {
      * @param index Index of the end query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getEnd(final int index) {
         return ListUtil.get(this.end, index);
     }

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/ProcessStepQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/ProcessStepQuery.java
@@ -44,14 +44,14 @@ public class ProcessStepQuery extends BaseObjectQuery {
     }
 
     @Override
-    @JsonIgnore
+
     public ProcessStepQuery addTags(final List<FieldQuery> tags) {
         super.addTags(tags);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public ProcessStepQuery addTags(final FieldQuery tags) {
         super.addTags(tags);
         return this;
@@ -64,14 +64,14 @@ public class ProcessStepQuery extends BaseObjectQuery {
     }
 
     @Override
-    @JsonIgnore
+
     public ProcessStepQuery addLength(final List<FieldQuery> length) {
         super.addLength(length);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public ProcessStepQuery addLength(final FieldQuery length) {
         super.addLength(length);
         return this;
@@ -84,14 +84,14 @@ public class ProcessStepQuery extends BaseObjectQuery {
     }
 
     @Override
-    @JsonIgnore
+
     public ProcessStepQuery addOffset(final List<FieldQuery> offset) {
         super.addOffset(offset);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public ProcessStepQuery addOffset(final FieldQuery offset) {
         super.addOffset(offset);
         return this;
@@ -114,7 +114,7 @@ public class ProcessStepQuery extends BaseObjectQuery {
      * @param name {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ProcessStepQuery addName(final List<FieldQuery> name) {
         this.name = ListUtil.add(name, this.name);
         return this;
@@ -126,7 +126,7 @@ public class ProcessStepQuery extends BaseObjectQuery {
      * @param name {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ProcessStepQuery addName(final FieldQuery name) {
         this.name = ListUtil.add(name, this.name);
         return this;
@@ -137,7 +137,7 @@ public class ProcessStepQuery extends BaseObjectQuery {
      *
      * @return Number of name queries.
      */
-    @JsonIgnore
+
     public int nameLength() {
         return ListUtil.length(this.name);
     }
@@ -147,7 +147,7 @@ public class ProcessStepQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> name() {
         return ListUtil.iterable(this.name);
     }
@@ -158,7 +158,7 @@ public class ProcessStepQuery extends BaseObjectQuery {
      * @param index Index of the name query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getName(final int index) {
         return ListUtil.get(this.name, index);
     }
@@ -189,7 +189,7 @@ public class ProcessStepQuery extends BaseObjectQuery {
      * @param details {@link ValueQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ProcessStepQuery addDetails(final List<ValueQuery> details) {
         this.details = ListUtil.add(details, this.details);
         return this;
@@ -201,7 +201,7 @@ public class ProcessStepQuery extends BaseObjectQuery {
      * @param details {@link ValueQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ProcessStepQuery addDetails(final ValueQuery details) {
         this.details = ListUtil.add(details, this.details);
         return this;
@@ -212,7 +212,7 @@ public class ProcessStepQuery extends BaseObjectQuery {
      *
      * @return Number of details queries.
      */
-    @JsonIgnore
+
     public int detailsLength() {
         return ListUtil.length(this.details);
     }
@@ -222,7 +222,7 @@ public class ProcessStepQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link ValueQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<ValueQuery> details() {
         return ListUtil.iterable(this.details);
     }
@@ -233,7 +233,7 @@ public class ProcessStepQuery extends BaseObjectQuery {
      * @param index Index of the details query to get.
      * @return {@link ValueQuery} at the input index.
      */
-    @JsonIgnore
+
     public ValueQuery getDetails(final int index) {
         return ListUtil.get(this.details, index);
     }

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/PropertyQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/PropertyQuery.java
@@ -44,14 +44,14 @@ public class PropertyQuery extends ValueQuery {
     }
 
     @Override
-    @JsonIgnore
+
     public PropertyQuery addTags(final List<FieldQuery> tags) {
         super.addTags(tags);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public PropertyQuery addTags(final FieldQuery tags) {
         super.addTags(tags);
         return this;
@@ -64,14 +64,14 @@ public class PropertyQuery extends ValueQuery {
     }
 
     @Override
-    @JsonIgnore
+
     public PropertyQuery addLength(final List<FieldQuery> length) {
         super.addLength(length);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public PropertyQuery addLength(final FieldQuery length) {
         super.addLength(length);
         return this;
@@ -84,14 +84,14 @@ public class PropertyQuery extends ValueQuery {
     }
 
     @Override
-    @JsonIgnore
+
     public PropertyQuery addOffset(final List<FieldQuery> offset) {
         super.addOffset(offset);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public PropertyQuery addOffset(final FieldQuery offset) {
         super.addOffset(offset);
         return this;
@@ -104,14 +104,14 @@ public class PropertyQuery extends ValueQuery {
     }
 
     @Override
-    @JsonIgnore
+
     public PropertyQuery addName(final List<FieldQuery> name) {
         super.addName(name);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public PropertyQuery addName(final FieldQuery name) {
         super.addName(name);
         return this;
@@ -124,14 +124,14 @@ public class PropertyQuery extends ValueQuery {
     }
 
     @Override
-    @JsonIgnore
+
     public PropertyQuery addValue(final List<FieldQuery> value) {
         super.addValue(value);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public PropertyQuery addValue(final FieldQuery value) {
         super.addValue(value);
         return this;
@@ -144,14 +144,14 @@ public class PropertyQuery extends ValueQuery {
     }
 
     @Override
-    @JsonIgnore
+
     public PropertyQuery addFile(final List<FileReferenceQuery> file) {
         super.addFile(file);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public PropertyQuery addFile(final FileReferenceQuery file) {
         super.addFile(file);
         return this;
@@ -164,14 +164,14 @@ public class PropertyQuery extends ValueQuery {
     }
 
     @Override
-    @JsonIgnore
+
     public PropertyQuery addUnits(final List<FieldQuery> units) {
         super.addUnits(units);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public PropertyQuery addUnits(final FieldQuery units) {
         super.addUnits(units);
         return this;
@@ -194,7 +194,7 @@ public class PropertyQuery extends ValueQuery {
      * @param conditions {@link ValueQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public PropertyQuery addConditions(final List<ValueQuery> conditions) {
         this.conditions = ListUtil.add(conditions, this.conditions);
         return this;
@@ -206,7 +206,7 @@ public class PropertyQuery extends ValueQuery {
      * @param conditions {@link ValueQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public PropertyQuery addConditions(final ValueQuery conditions) {
         this.conditions = ListUtil.add(conditions, this.conditions);
         return this;
@@ -217,7 +217,7 @@ public class PropertyQuery extends ValueQuery {
      *
      * @return Number of conditions queries.
      */
-    @JsonIgnore
+
     public int conditionsLength() {
         return ListUtil.length(this.conditions);
     }
@@ -227,7 +227,7 @@ public class PropertyQuery extends ValueQuery {
      *
      * @return Iterable of {@link ValueQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<ValueQuery> conditions() {
         return ListUtil.iterable(this.conditions);
     }
@@ -238,7 +238,7 @@ public class PropertyQuery extends ValueQuery {
      * @param index Index of the conditions query to get.
      * @return {@link ValueQuery} at the input index.
      */
-    @JsonIgnore
+
     public ValueQuery getConditions(final int index) {
         return ListUtil.get(this.conditions, index);
     }
@@ -269,7 +269,7 @@ public class PropertyQuery extends ValueQuery {
      * @param dataType {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public PropertyQuery addDataType(final List<FieldQuery> dataType) {
         this.dataType = ListUtil.add(dataType, this.dataType);
         return this;
@@ -281,7 +281,7 @@ public class PropertyQuery extends ValueQuery {
      * @param dataType {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public PropertyQuery addDataType(final FieldQuery dataType) {
         this.dataType = ListUtil.add(dataType, this.dataType);
         return this;
@@ -292,7 +292,7 @@ public class PropertyQuery extends ValueQuery {
      *
      * @return Number of dataType queries.
      */
-    @JsonIgnore
+
     public int dataTypeLength() {
         return ListUtil.length(this.dataType);
     }
@@ -302,7 +302,7 @@ public class PropertyQuery extends ValueQuery {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> dataType() {
         return ListUtil.iterable(this.dataType);
     }
@@ -313,7 +313,7 @@ public class PropertyQuery extends ValueQuery {
      * @param index Index of the dataType query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getDataType(final int index) {
         return ListUtil.get(this.dataType, index);
     }

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/QuantityQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/QuantityQuery.java
@@ -44,14 +44,14 @@ public class QuantityQuery extends BaseObjectQuery {
     }
 
     @Override
-    @JsonIgnore
+
     public QuantityQuery addTags(final List<FieldQuery> tags) {
         super.addTags(tags);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public QuantityQuery addTags(final FieldQuery tags) {
         super.addTags(tags);
         return this;
@@ -64,14 +64,14 @@ public class QuantityQuery extends BaseObjectQuery {
     }
 
     @Override
-    @JsonIgnore
+
     public QuantityQuery addLength(final List<FieldQuery> length) {
         super.addLength(length);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public QuantityQuery addLength(final FieldQuery length) {
         super.addLength(length);
         return this;
@@ -84,14 +84,14 @@ public class QuantityQuery extends BaseObjectQuery {
     }
 
     @Override
-    @JsonIgnore
+
     public QuantityQuery addOffset(final List<FieldQuery> offset) {
         super.addOffset(offset);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public QuantityQuery addOffset(final FieldQuery offset) {
         super.addOffset(offset);
         return this;
@@ -114,7 +114,7 @@ public class QuantityQuery extends BaseObjectQuery {
      * @param actualMassPercent {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public QuantityQuery addActualMassPercent(final List<FieldQuery> actualMassPercent) {
         this.actualMassPercent = ListUtil.add(actualMassPercent, this.actualMassPercent);
         return this;
@@ -126,7 +126,7 @@ public class QuantityQuery extends BaseObjectQuery {
      * @param actualMassPercent {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public QuantityQuery addActualMassPercent(final FieldQuery actualMassPercent) {
         this.actualMassPercent = ListUtil.add(actualMassPercent, this.actualMassPercent);
         return this;
@@ -137,7 +137,7 @@ public class QuantityQuery extends BaseObjectQuery {
      *
      * @return Number of actualMassPercent queries.
      */
-    @JsonIgnore
+
     public int actualMassPercentLength() {
         return ListUtil.length(this.actualMassPercent);
     }
@@ -147,7 +147,7 @@ public class QuantityQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> actualMassPercent() {
         return ListUtil.iterable(this.actualMassPercent);
     }
@@ -158,7 +158,7 @@ public class QuantityQuery extends BaseObjectQuery {
      * @param index Index of the actualMassPercent query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getActualMassPercent(final int index) {
         return ListUtil.get(this.actualMassPercent, index);
     }
@@ -189,7 +189,7 @@ public class QuantityQuery extends BaseObjectQuery {
      * @param actualVolumePercent {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public QuantityQuery addActualVolumePercent(final List<FieldQuery> actualVolumePercent) {
         this.actualVolumePercent = ListUtil.add(actualVolumePercent, this.actualVolumePercent);
         return this;
@@ -201,7 +201,7 @@ public class QuantityQuery extends BaseObjectQuery {
      * @param actualVolumePercent {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public QuantityQuery addActualVolumePercent(final FieldQuery actualVolumePercent) {
         this.actualVolumePercent = ListUtil.add(actualVolumePercent, this.actualVolumePercent);
         return this;
@@ -212,7 +212,7 @@ public class QuantityQuery extends BaseObjectQuery {
      *
      * @return Number of actualVolumePercent queries.
      */
-    @JsonIgnore
+
     public int actualVolumePercentLength() {
         return ListUtil.length(this.actualVolumePercent);
     }
@@ -222,7 +222,7 @@ public class QuantityQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> actualVolumePercent() {
         return ListUtil.iterable(this.actualVolumePercent);
     }
@@ -233,7 +233,7 @@ public class QuantityQuery extends BaseObjectQuery {
      * @param index Index of the actualVolumePercent query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getActualVolumePercent(final int index) {
         return ListUtil.get(this.actualVolumePercent, index);
     }
@@ -264,7 +264,7 @@ public class QuantityQuery extends BaseObjectQuery {
      * @param actualNumberPercent {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public QuantityQuery addActualNumberPercent(final List<FieldQuery> actualNumberPercent) {
         this.actualNumberPercent = ListUtil.add(actualNumberPercent, this.actualNumberPercent);
         return this;
@@ -276,7 +276,7 @@ public class QuantityQuery extends BaseObjectQuery {
      * @param actualNumberPercent {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public QuantityQuery addActualNumberPercent(final FieldQuery actualNumberPercent) {
         this.actualNumberPercent = ListUtil.add(actualNumberPercent, this.actualNumberPercent);
         return this;
@@ -287,7 +287,7 @@ public class QuantityQuery extends BaseObjectQuery {
      *
      * @return Number of actualNumberPercent queries.
      */
-    @JsonIgnore
+
     public int actualNumberPercentLength() {
         return ListUtil.length(this.actualNumberPercent);
     }
@@ -297,7 +297,7 @@ public class QuantityQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> actualNumberPercent() {
         return ListUtil.iterable(this.actualNumberPercent);
     }
@@ -308,7 +308,7 @@ public class QuantityQuery extends BaseObjectQuery {
      * @param index Index of the actualNumberPercent query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getActualNumberPercent(final int index) {
         return ListUtil.get(this.actualNumberPercent, index);
     }
@@ -339,7 +339,7 @@ public class QuantityQuery extends BaseObjectQuery {
      * @param idealMassPercent {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public QuantityQuery addIdealMassPercent(final List<FieldQuery> idealMassPercent) {
         this.idealMassPercent = ListUtil.add(idealMassPercent, this.idealMassPercent);
         return this;
@@ -351,7 +351,7 @@ public class QuantityQuery extends BaseObjectQuery {
      * @param idealMassPercent {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public QuantityQuery addIdealMassPercent(final FieldQuery idealMassPercent) {
         this.idealMassPercent = ListUtil.add(idealMassPercent, this.idealMassPercent);
         return this;
@@ -362,7 +362,7 @@ public class QuantityQuery extends BaseObjectQuery {
      *
      * @return Number of idealMassPercent queries.
      */
-    @JsonIgnore
+
     public int idealMassPercentLength() {
         return ListUtil.length(this.idealMassPercent);
     }
@@ -372,7 +372,7 @@ public class QuantityQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> idealMassPercent() {
         return ListUtil.iterable(this.idealMassPercent);
     }
@@ -383,7 +383,7 @@ public class QuantityQuery extends BaseObjectQuery {
      * @param index Index of the idealMassPercent query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getIdealMassPercent(final int index) {
         return ListUtil.get(this.idealMassPercent, index);
     }
@@ -414,7 +414,7 @@ public class QuantityQuery extends BaseObjectQuery {
      * @param idealVolumePercent {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public QuantityQuery addIdealVolumePercent(final List<FieldQuery> idealVolumePercent) {
         this.idealVolumePercent = ListUtil.add(idealVolumePercent, this.idealVolumePercent);
         return this;
@@ -426,7 +426,7 @@ public class QuantityQuery extends BaseObjectQuery {
      * @param idealVolumePercent {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public QuantityQuery addIdealVolumePercent(final FieldQuery idealVolumePercent) {
         this.idealVolumePercent = ListUtil.add(idealVolumePercent, this.idealVolumePercent);
         return this;
@@ -437,7 +437,7 @@ public class QuantityQuery extends BaseObjectQuery {
      *
      * @return Number of idealVolumePercent queries.
      */
-    @JsonIgnore
+
     public int idealVolumePercentLength() {
         return ListUtil.length(this.idealVolumePercent);
     }
@@ -447,7 +447,7 @@ public class QuantityQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> idealVolumePercent() {
         return ListUtil.iterable(this.idealVolumePercent);
     }
@@ -458,7 +458,7 @@ public class QuantityQuery extends BaseObjectQuery {
      * @param index Index of the idealVolumePercent query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getIdealVolumePercent(final int index) {
         return ListUtil.get(this.idealVolumePercent, index);
     }
@@ -489,7 +489,7 @@ public class QuantityQuery extends BaseObjectQuery {
      * @param idealNumberPercent {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public QuantityQuery addIdealNumberPercent(final List<FieldQuery> idealNumberPercent) {
         this.idealNumberPercent = ListUtil.add(idealNumberPercent, this.idealNumberPercent);
         return this;
@@ -501,7 +501,7 @@ public class QuantityQuery extends BaseObjectQuery {
      * @param idealNumberPercent {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public QuantityQuery addIdealNumberPercent(final FieldQuery idealNumberPercent) {
         this.idealNumberPercent = ListUtil.add(idealNumberPercent, this.idealNumberPercent);
         return this;
@@ -512,7 +512,7 @@ public class QuantityQuery extends BaseObjectQuery {
      *
      * @return Number of idealNumberPercent queries.
      */
-    @JsonIgnore
+
     public int idealNumberPercentLength() {
         return ListUtil.length(this.idealNumberPercent);
     }
@@ -522,7 +522,7 @@ public class QuantityQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> idealNumberPercent() {
         return ListUtil.iterable(this.idealNumberPercent);
     }
@@ -533,7 +533,7 @@ public class QuantityQuery extends BaseObjectQuery {
      * @param index Index of the idealNumberPercent query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getIdealNumberPercent(final int index) {
         return ListUtil.get(this.idealNumberPercent, index);
     }

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/ReferenceQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/ReferenceQuery.java
@@ -44,14 +44,14 @@ public class ReferenceQuery extends BaseObjectQuery {
     }
 
     @Override
-    @JsonIgnore
+
     public ReferenceQuery addTags(final List<FieldQuery> tags) {
         super.addTags(tags);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public ReferenceQuery addTags(final FieldQuery tags) {
         super.addTags(tags);
         return this;
@@ -64,14 +64,14 @@ public class ReferenceQuery extends BaseObjectQuery {
     }
 
     @Override
-    @JsonIgnore
+
     public ReferenceQuery addLength(final List<FieldQuery> length) {
         super.addLength(length);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public ReferenceQuery addLength(final FieldQuery length) {
         super.addLength(length);
         return this;
@@ -84,14 +84,14 @@ public class ReferenceQuery extends BaseObjectQuery {
     }
 
     @Override
-    @JsonIgnore
+
     public ReferenceQuery addOffset(final List<FieldQuery> offset) {
         super.addOffset(offset);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public ReferenceQuery addOffset(final FieldQuery offset) {
         super.addOffset(offset);
         return this;
@@ -114,7 +114,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param doi {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ReferenceQuery addDoi(final List<FieldQuery> doi) {
         this.doi = ListUtil.add(doi, this.doi);
         return this;
@@ -126,7 +126,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param doi {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ReferenceQuery addDoi(final FieldQuery doi) {
         this.doi = ListUtil.add(doi, this.doi);
         return this;
@@ -137,7 +137,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      *
      * @return Number of doi queries.
      */
-    @JsonIgnore
+
     public int doiLength() {
         return ListUtil.length(this.doi);
     }
@@ -147,7 +147,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> doi() {
         return ListUtil.iterable(this.doi);
     }
@@ -158,7 +158,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param index Index of the doi query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getDoi(final int index) {
         return ListUtil.get(this.doi, index);
     }
@@ -189,7 +189,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param isbn {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ReferenceQuery addIsbn(final List<FieldQuery> isbn) {
         this.isbn = ListUtil.add(isbn, this.isbn);
         return this;
@@ -201,7 +201,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param isbn {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ReferenceQuery addIsbn(final FieldQuery isbn) {
         this.isbn = ListUtil.add(isbn, this.isbn);
         return this;
@@ -212,7 +212,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      *
      * @return Number of isbn queries.
      */
-    @JsonIgnore
+
     public int isbnLength() {
         return ListUtil.length(this.isbn);
     }
@@ -222,7 +222,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> isbn() {
         return ListUtil.iterable(this.isbn);
     }
@@ -233,7 +233,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param index Index of the isbn query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getIsbn(final int index) {
         return ListUtil.get(this.isbn, index);
     }
@@ -264,7 +264,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param issn {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ReferenceQuery addIssn(final List<FieldQuery> issn) {
         this.issn = ListUtil.add(issn, this.issn);
         return this;
@@ -276,7 +276,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param issn {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ReferenceQuery addIssn(final FieldQuery issn) {
         this.issn = ListUtil.add(issn, this.issn);
         return this;
@@ -287,7 +287,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      *
      * @return Number of issn queries.
      */
-    @JsonIgnore
+
     public int issnLength() {
         return ListUtil.length(this.issn);
     }
@@ -297,7 +297,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> issn() {
         return ListUtil.iterable(this.issn);
     }
@@ -308,7 +308,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param index Index of the issn query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getIssn(final int index) {
         return ListUtil.get(this.issn, index);
     }
@@ -339,7 +339,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param url {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ReferenceQuery addUrl(final List<FieldQuery> url) {
         this.url = ListUtil.add(url, this.url);
         return this;
@@ -351,7 +351,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param url {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ReferenceQuery addUrl(final FieldQuery url) {
         this.url = ListUtil.add(url, this.url);
         return this;
@@ -362,7 +362,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      *
      * @return Number of url queries.
      */
-    @JsonIgnore
+
     public int urlLength() {
         return ListUtil.length(this.url);
     }
@@ -372,7 +372,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> url() {
         return ListUtil.iterable(this.url);
     }
@@ -383,7 +383,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param index Index of the url query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getUrl(final int index) {
         return ListUtil.get(this.url, index);
     }
@@ -414,7 +414,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param title {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ReferenceQuery addTitle(final List<FieldQuery> title) {
         this.title = ListUtil.add(title, this.title);
         return this;
@@ -426,7 +426,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param title {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ReferenceQuery addTitle(final FieldQuery title) {
         this.title = ListUtil.add(title, this.title);
         return this;
@@ -437,7 +437,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      *
      * @return Number of title queries.
      */
-    @JsonIgnore
+
     public int titleLength() {
         return ListUtil.length(this.title);
     }
@@ -447,7 +447,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> title() {
         return ListUtil.iterable(this.title);
     }
@@ -458,7 +458,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param index Index of the title query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getTitle(final int index) {
         return ListUtil.get(this.title, index);
     }
@@ -489,7 +489,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param publisher {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ReferenceQuery addPublisher(final List<FieldQuery> publisher) {
         this.publisher = ListUtil.add(publisher, this.publisher);
         return this;
@@ -501,7 +501,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param publisher {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ReferenceQuery addPublisher(final FieldQuery publisher) {
         this.publisher = ListUtil.add(publisher, this.publisher);
         return this;
@@ -512,7 +512,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      *
      * @return Number of publisher queries.
      */
-    @JsonIgnore
+
     public int publisherLength() {
         return ListUtil.length(this.publisher);
     }
@@ -522,7 +522,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> publisher() {
         return ListUtil.iterable(this.publisher);
     }
@@ -533,7 +533,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param index Index of the publisher query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getPublisher(final int index) {
         return ListUtil.get(this.publisher, index);
     }
@@ -564,7 +564,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param journal {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ReferenceQuery addJournal(final List<FieldQuery> journal) {
         this.journal = ListUtil.add(journal, this.journal);
         return this;
@@ -576,7 +576,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param journal {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ReferenceQuery addJournal(final FieldQuery journal) {
         this.journal = ListUtil.add(journal, this.journal);
         return this;
@@ -587,7 +587,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      *
      * @return Number of journal queries.
      */
-    @JsonIgnore
+
     public int journalLength() {
         return ListUtil.length(this.journal);
     }
@@ -597,7 +597,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> journal() {
         return ListUtil.iterable(this.journal);
     }
@@ -608,7 +608,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param index Index of the journal query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getJournal(final int index) {
         return ListUtil.get(this.journal, index);
     }
@@ -639,7 +639,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param volume {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ReferenceQuery addVolume(final List<FieldQuery> volume) {
         this.volume = ListUtil.add(volume, this.volume);
         return this;
@@ -651,7 +651,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param volume {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ReferenceQuery addVolume(final FieldQuery volume) {
         this.volume = ListUtil.add(volume, this.volume);
         return this;
@@ -662,7 +662,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      *
      * @return Number of volume queries.
      */
-    @JsonIgnore
+
     public int volumeLength() {
         return ListUtil.length(this.volume);
     }
@@ -672,7 +672,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> volume() {
         return ListUtil.iterable(this.volume);
     }
@@ -683,7 +683,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param index Index of the volume query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getVolume(final int index) {
         return ListUtil.get(this.volume, index);
     }
@@ -714,7 +714,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param issue {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ReferenceQuery addIssue(final List<FieldQuery> issue) {
         this.issue = ListUtil.add(issue, this.issue);
         return this;
@@ -726,7 +726,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param issue {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ReferenceQuery addIssue(final FieldQuery issue) {
         this.issue = ListUtil.add(issue, this.issue);
         return this;
@@ -737,7 +737,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      *
      * @return Number of issue queries.
      */
-    @JsonIgnore
+
     public int issueLength() {
         return ListUtil.length(this.issue);
     }
@@ -747,7 +747,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> issue() {
         return ListUtil.iterable(this.issue);
     }
@@ -758,7 +758,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param index Index of the issue query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getIssue(final int index) {
         return ListUtil.get(this.issue, index);
     }
@@ -789,7 +789,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param year {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ReferenceQuery addYear(final List<FieldQuery> year) {
         this.year = ListUtil.add(year, this.year);
         return this;
@@ -801,7 +801,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param year {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ReferenceQuery addYear(final FieldQuery year) {
         this.year = ListUtil.add(year, this.year);
         return this;
@@ -812,7 +812,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      *
      * @return Number of year queries.
      */
-    @JsonIgnore
+
     public int yearLength() {
         return ListUtil.length(this.year);
     }
@@ -822,7 +822,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> year() {
         return ListUtil.iterable(this.year);
     }
@@ -833,7 +833,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param index Index of the year query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getYear(final int index) {
         return ListUtil.get(this.year, index);
     }
@@ -864,7 +864,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param figure {@link DisplayItemQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ReferenceQuery addFigure(final List<DisplayItemQuery> figure) {
         this.figure = ListUtil.add(figure, this.figure);
         return this;
@@ -876,7 +876,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param figure {@link DisplayItemQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ReferenceQuery addFigure(final DisplayItemQuery figure) {
         this.figure = ListUtil.add(figure, this.figure);
         return this;
@@ -887,7 +887,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      *
      * @return Number of figure queries.
      */
-    @JsonIgnore
+
     public int figureLength() {
         return ListUtil.length(this.figure);
     }
@@ -897,7 +897,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link DisplayItemQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<DisplayItemQuery> figure() {
         return ListUtil.iterable(this.figure);
     }
@@ -908,7 +908,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param index Index of the figure query to get.
      * @return {@link DisplayItemQuery} at the input index.
      */
-    @JsonIgnore
+
     public DisplayItemQuery getFigure(final int index) {
         return ListUtil.get(this.figure, index);
     }
@@ -939,7 +939,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param table {@link DisplayItemQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ReferenceQuery addTable(final List<DisplayItemQuery> table) {
         this.table = ListUtil.add(table, this.table);
         return this;
@@ -951,7 +951,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param table {@link DisplayItemQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ReferenceQuery addTable(final DisplayItemQuery table) {
         this.table = ListUtil.add(table, this.table);
         return this;
@@ -962,7 +962,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      *
      * @return Number of table queries.
      */
-    @JsonIgnore
+
     public int tableLength() {
         return ListUtil.length(this.table);
     }
@@ -972,7 +972,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link DisplayItemQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<DisplayItemQuery> table() {
         return ListUtil.iterable(this.table);
     }
@@ -983,7 +983,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param index Index of the table query to get.
      * @return {@link DisplayItemQuery} at the input index.
      */
-    @JsonIgnore
+
     public DisplayItemQuery getTable(final int index) {
         return ListUtil.get(this.table, index);
     }
@@ -1014,7 +1014,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param pages {@link PagesQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ReferenceQuery addPages(final List<PagesQuery> pages) {
         this.pages = ListUtil.add(pages, this.pages);
         return this;
@@ -1026,7 +1026,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param pages {@link PagesQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ReferenceQuery addPages(final PagesQuery pages) {
         this.pages = ListUtil.add(pages, this.pages);
         return this;
@@ -1037,7 +1037,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      *
      * @return Number of pages queries.
      */
-    @JsonIgnore
+
     public int pagesLength() {
         return ListUtil.length(this.pages);
     }
@@ -1047,7 +1047,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link PagesQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<PagesQuery> pages() {
         return ListUtil.iterable(this.pages);
     }
@@ -1058,7 +1058,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param index Index of the pages query to get.
      * @return {@link PagesQuery} at the input index.
      */
-    @JsonIgnore
+
     public PagesQuery getPages(final int index) {
         return ListUtil.get(this.pages, index);
     }
@@ -1089,7 +1089,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param authors {@link NameQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ReferenceQuery addAuthors(final List<NameQuery> authors) {
         this.authors = ListUtil.add(authors, this.authors);
         return this;
@@ -1101,7 +1101,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param authors {@link NameQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ReferenceQuery addAuthors(final NameQuery authors) {
         this.authors = ListUtil.add(authors, this.authors);
         return this;
@@ -1112,7 +1112,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      *
      * @return Number of authors queries.
      */
-    @JsonIgnore
+
     public int authorsLength() {
         return ListUtil.length(this.authors);
     }
@@ -1122,7 +1122,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link NameQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<NameQuery> authors() {
         return ListUtil.iterable(this.authors);
     }
@@ -1133,7 +1133,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param index Index of the authors query to get.
      * @return {@link NameQuery} at the input index.
      */
-    @JsonIgnore
+
     public NameQuery getAuthors(final int index) {
         return ListUtil.get(this.authors, index);
     }
@@ -1164,7 +1164,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param editors {@link NameQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ReferenceQuery addEditors(final List<NameQuery> editors) {
         this.editors = ListUtil.add(editors, this.editors);
         return this;
@@ -1176,7 +1176,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param editors {@link NameQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ReferenceQuery addEditors(final NameQuery editors) {
         this.editors = ListUtil.add(editors, this.editors);
         return this;
@@ -1187,7 +1187,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      *
      * @return Number of editors queries.
      */
-    @JsonIgnore
+
     public int editorsLength() {
         return ListUtil.length(this.editors);
     }
@@ -1197,7 +1197,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link NameQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<NameQuery> editors() {
         return ListUtil.iterable(this.editors);
     }
@@ -1208,7 +1208,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param index Index of the editors query to get.
      * @return {@link NameQuery} at the input index.
      */
-    @JsonIgnore
+
     public NameQuery getEditors(final int index) {
         return ListUtil.get(this.editors, index);
     }
@@ -1239,7 +1239,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param affiliations {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ReferenceQuery addAffiliations(final List<FieldQuery> affiliations) {
         this.affiliations = ListUtil.add(affiliations, this.affiliations);
         return this;
@@ -1251,7 +1251,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param affiliations {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ReferenceQuery addAffiliations(final FieldQuery affiliations) {
         this.affiliations = ListUtil.add(affiliations, this.affiliations);
         return this;
@@ -1262,7 +1262,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      *
      * @return Number of affiliations queries.
      */
-    @JsonIgnore
+
     public int affiliationsLength() {
         return ListUtil.length(this.affiliations);
     }
@@ -1272,7 +1272,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> affiliations() {
         return ListUtil.iterable(this.affiliations);
     }
@@ -1283,7 +1283,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param index Index of the affiliations query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getAffiliations(final int index) {
         return ListUtil.get(this.affiliations, index);
     }
@@ -1314,7 +1314,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param acknowledgements {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ReferenceQuery addAcknowledgements(final List<FieldQuery> acknowledgements) {
         this.acknowledgements = ListUtil.add(acknowledgements, this.acknowledgements);
         return this;
@@ -1326,7 +1326,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param acknowledgements {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ReferenceQuery addAcknowledgements(final FieldQuery acknowledgements) {
         this.acknowledgements = ListUtil.add(acknowledgements, this.acknowledgements);
         return this;
@@ -1337,7 +1337,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      *
      * @return Number of acknowledgements queries.
      */
-    @JsonIgnore
+
     public int acknowledgementsLength() {
         return ListUtil.length(this.acknowledgements);
     }
@@ -1347,7 +1347,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> acknowledgements() {
         return ListUtil.iterable(this.acknowledgements);
     }
@@ -1358,7 +1358,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param index Index of the acknowledgements query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getAcknowledgements(final int index) {
         return ListUtil.get(this.acknowledgements, index);
     }
@@ -1389,7 +1389,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param references {@link ReferenceQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ReferenceQuery addReferences(final List<ReferenceQuery> references) {
         this.references = ListUtil.add(references, this.references);
         return this;
@@ -1401,7 +1401,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param references {@link ReferenceQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ReferenceQuery addReferences(final ReferenceQuery references) {
         this.references = ListUtil.add(references, this.references);
         return this;
@@ -1412,7 +1412,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      *
      * @return Number of references queries.
      */
-    @JsonIgnore
+
     public int referencesLength() {
         return ListUtil.length(this.references);
     }
@@ -1422,7 +1422,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link ReferenceQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<ReferenceQuery> references() {
         return ListUtil.iterable(this.references);
     }
@@ -1433,7 +1433,7 @@ public class ReferenceQuery extends BaseObjectQuery {
      * @param index Index of the references query to get.
      * @return {@link ReferenceQuery} at the input index.
      */
-    @JsonIgnore
+
     public ReferenceQuery getReferences(final int index) {
         return ListUtil.get(this.references, index);
     }

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/SourceQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/SourceQuery.java
@@ -44,14 +44,14 @@ public class SourceQuery extends BaseObjectQuery {
     }
 
     @Override
-    @JsonIgnore
+
     public SourceQuery addTags(final List<FieldQuery> tags) {
         super.addTags(tags);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public SourceQuery addTags(final FieldQuery tags) {
         super.addTags(tags);
         return this;
@@ -64,14 +64,14 @@ public class SourceQuery extends BaseObjectQuery {
     }
 
     @Override
-    @JsonIgnore
+
     public SourceQuery addLength(final List<FieldQuery> length) {
         super.addLength(length);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public SourceQuery addLength(final FieldQuery length) {
         super.addLength(length);
         return this;
@@ -84,14 +84,14 @@ public class SourceQuery extends BaseObjectQuery {
     }
 
     @Override
-    @JsonIgnore
+
     public SourceQuery addOffset(final List<FieldQuery> offset) {
         super.addOffset(offset);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public SourceQuery addOffset(final FieldQuery offset) {
         super.addOffset(offset);
         return this;
@@ -114,7 +114,7 @@ public class SourceQuery extends BaseObjectQuery {
      * @param producer {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public SourceQuery addProducer(final List<FieldQuery> producer) {
         this.producer = ListUtil.add(producer, this.producer);
         return this;
@@ -126,7 +126,7 @@ public class SourceQuery extends BaseObjectQuery {
      * @param producer {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public SourceQuery addProducer(final FieldQuery producer) {
         this.producer = ListUtil.add(producer, this.producer);
         return this;
@@ -137,7 +137,7 @@ public class SourceQuery extends BaseObjectQuery {
      *
      * @return Number of producer queries.
      */
-    @JsonIgnore
+
     public int producerLength() {
         return ListUtil.length(this.producer);
     }
@@ -147,7 +147,7 @@ public class SourceQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> producer() {
         return ListUtil.iterable(this.producer);
     }
@@ -158,7 +158,7 @@ public class SourceQuery extends BaseObjectQuery {
      * @param index Index of the producer query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getProducer(final int index) {
         return ListUtil.get(this.producer, index);
     }
@@ -189,7 +189,7 @@ public class SourceQuery extends BaseObjectQuery {
      * @param url {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public SourceQuery addUrl(final List<FieldQuery> url) {
         this.url = ListUtil.add(url, this.url);
         return this;
@@ -201,7 +201,7 @@ public class SourceQuery extends BaseObjectQuery {
      * @param url {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public SourceQuery addUrl(final FieldQuery url) {
         this.url = ListUtil.add(url, this.url);
         return this;
@@ -212,7 +212,7 @@ public class SourceQuery extends BaseObjectQuery {
      *
      * @return Number of url queries.
      */
-    @JsonIgnore
+
     public int urlLength() {
         return ListUtil.length(this.url);
     }
@@ -222,7 +222,7 @@ public class SourceQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> url() {
         return ListUtil.iterable(this.url);
     }
@@ -233,7 +233,7 @@ public class SourceQuery extends BaseObjectQuery {
      * @param index Index of the url query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getUrl(final int index) {
         return ListUtil.get(this.url, index);
     }

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/ValueQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/ValueQuery.java
@@ -44,14 +44,14 @@ public class ValueQuery extends BaseObjectQuery {
     }
 
     @Override
-    @JsonIgnore
+
     public ValueQuery addTags(final List<FieldQuery> tags) {
         super.addTags(tags);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public ValueQuery addTags(final FieldQuery tags) {
         super.addTags(tags);
         return this;
@@ -64,14 +64,14 @@ public class ValueQuery extends BaseObjectQuery {
     }
 
     @Override
-    @JsonIgnore
+
     public ValueQuery addLength(final List<FieldQuery> length) {
         super.addLength(length);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public ValueQuery addLength(final FieldQuery length) {
         super.addLength(length);
         return this;
@@ -84,14 +84,14 @@ public class ValueQuery extends BaseObjectQuery {
     }
 
     @Override
-    @JsonIgnore
+
     public ValueQuery addOffset(final List<FieldQuery> offset) {
         super.addOffset(offset);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public ValueQuery addOffset(final FieldQuery offset) {
         super.addOffset(offset);
         return this;
@@ -114,7 +114,7 @@ public class ValueQuery extends BaseObjectQuery {
      * @param name {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ValueQuery addName(final List<FieldQuery> name) {
         this.name = ListUtil.add(name, this.name);
         return this;
@@ -126,7 +126,7 @@ public class ValueQuery extends BaseObjectQuery {
      * @param name {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ValueQuery addName(final FieldQuery name) {
         this.name = ListUtil.add(name, this.name);
         return this;
@@ -137,7 +137,7 @@ public class ValueQuery extends BaseObjectQuery {
      *
      * @return Number of name queries.
      */
-    @JsonIgnore
+
     public int nameLength() {
         return ListUtil.length(this.name);
     }
@@ -147,7 +147,7 @@ public class ValueQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> name() {
         return ListUtil.iterable(this.name);
     }
@@ -158,7 +158,7 @@ public class ValueQuery extends BaseObjectQuery {
      * @param index Index of the name query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getName(final int index) {
         return ListUtil.get(this.name, index);
     }
@@ -189,7 +189,7 @@ public class ValueQuery extends BaseObjectQuery {
      * @param value {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ValueQuery addValue(final List<FieldQuery> value) {
         this.value = ListUtil.add(value, this.value);
         return this;
@@ -201,7 +201,7 @@ public class ValueQuery extends BaseObjectQuery {
      * @param value {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ValueQuery addValue(final FieldQuery value) {
         this.value = ListUtil.add(value, this.value);
         return this;
@@ -212,7 +212,7 @@ public class ValueQuery extends BaseObjectQuery {
      *
      * @return Number of value queries.
      */
-    @JsonIgnore
+
     public int valueLength() {
         return ListUtil.length(this.value);
     }
@@ -222,7 +222,7 @@ public class ValueQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> value() {
         return ListUtil.iterable(this.value);
     }
@@ -233,7 +233,7 @@ public class ValueQuery extends BaseObjectQuery {
      * @param index Index of the value query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getValue(final int index) {
         return ListUtil.get(this.value, index);
     }
@@ -264,7 +264,7 @@ public class ValueQuery extends BaseObjectQuery {
      * @param file {@link FileReferenceQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ValueQuery addFile(final List<FileReferenceQuery> file) {
         this.file = ListUtil.add(file, this.file);
         return this;
@@ -276,7 +276,7 @@ public class ValueQuery extends BaseObjectQuery {
      * @param file {@link FileReferenceQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ValueQuery addFile(final FileReferenceQuery file) {
         this.file = ListUtil.add(file, this.file);
         return this;
@@ -287,7 +287,7 @@ public class ValueQuery extends BaseObjectQuery {
      *
      * @return Number of file queries.
      */
-    @JsonIgnore
+
     public int fileLength() {
         return ListUtil.length(this.file);
     }
@@ -297,7 +297,7 @@ public class ValueQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link FileReferenceQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FileReferenceQuery> file() {
         return ListUtil.iterable(this.file);
     }
@@ -308,7 +308,7 @@ public class ValueQuery extends BaseObjectQuery {
      * @param index Index of the file query to get.
      * @return {@link FileReferenceQuery} at the input index.
      */
-    @JsonIgnore
+
     public FileReferenceQuery getFile(final int index) {
         return ListUtil.get(this.file, index);
     }
@@ -339,7 +339,7 @@ public class ValueQuery extends BaseObjectQuery {
      * @param units {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ValueQuery addUnits(final List<FieldQuery> units) {
         this.units = ListUtil.add(units, this.units);
         return this;
@@ -351,7 +351,7 @@ public class ValueQuery extends BaseObjectQuery {
      * @param units {@link FieldQuery} to add.
      * @return This object.
      */
-    @JsonIgnore
+
     public ValueQuery addUnits(final FieldQuery units) {
         this.units = ListUtil.add(units, this.units);
         return this;
@@ -362,7 +362,7 @@ public class ValueQuery extends BaseObjectQuery {
      *
      * @return Number of units queries.
      */
-    @JsonIgnore
+
     public int unitsLength() {
         return ListUtil.length(this.units);
     }
@@ -372,7 +372,7 @@ public class ValueQuery extends BaseObjectQuery {
      *
      * @return Iterable of {@link FieldQuery} objects.
      */
-    @JsonIgnore
+
     public Iterable<FieldQuery> units() {
         return ListUtil.iterable(this.units);
     }
@@ -383,7 +383,7 @@ public class ValueQuery extends BaseObjectQuery {
      * @param index Index of the units query to get.
      * @return {@link FieldQuery} at the input index.
      */
-    @JsonIgnore
+
     public FieldQuery getUnits(final int index) {
         return ListUtil.get(this.units, index);
     }

--- a/src/main/java/io/citrine/jcc/search/pif/result/PifSearchHit.java
+++ b/src/main/java/io/citrine/jcc/search/pif/result/PifSearchHit.java
@@ -157,7 +157,7 @@ public class PifSearchHit {
      * @param extracted Map of extracted value names to values.
      * @return This object.
      */
-    @JsonIgnore
+
     public PifSearchHit addExtracted(final Map<String, Object> extracted) {
         if (extracted != null) {
             if (this.extracted == null) {
@@ -175,7 +175,7 @@ public class PifSearchHit {
      * @param value Value that was extracted.
      * @return This object.
      */
-    @JsonIgnore
+
     public PifSearchHit addExtracted(final String key, final Object value) {
         if (this.extracted == null) {
             this.extracted = new HashMap<>();
@@ -199,7 +199,7 @@ public class PifSearchHit {
      *
      * @return Set with the extracted keys.
      */
-    @JsonIgnore
+
     public Set<String> getExtractedKeys() {
         return (this.extracted == null) ? Collections.emptySet() : this.extracted.keySet();
     }
@@ -210,7 +210,7 @@ public class PifSearchHit {
      * @param key String with the key of the extracted value.
      * @return String with the value of the input key or a null pointer if that key is not available.
      */
-    @JsonIgnore
+
     public Object getExtractedValue(final String key) {
         return (this.extracted == null) ? null : this.extracted.get(key);
     }
@@ -225,7 +225,7 @@ public class PifSearchHit {
      * @return Instance of the input class type generated from the value at the input key or a null pointer if the
      * key is not available.
      */
-    @JsonIgnore
+
     public <T extends Pio> T getExtractValue(final String key, final Class<T> valueClass) {
         return (this.extracted == null) ? null : convert(this.extracted.get(key), valueClass);
     }
@@ -237,7 +237,7 @@ public class PifSearchHit {
      * @param defaultValue String with the default value to return if the key does not exist.
      * @return Value with the input key or the input default.
      */
-    @JsonIgnore
+
     public Object getExtractedValueOrDefault(final String key, final Object defaultValue) {
         return (this.extracted == null) ? defaultValue : this.extracted.getOrDefault(key, defaultValue);
     }
@@ -251,7 +251,7 @@ public class PifSearchHit {
      * @param <T> Type of the value to extract.
      * @return Value with the input key or the input default.
      */
-    @JsonIgnore
+
     public <T extends Pio> T getExtractedValueOrDefault(
             final String key, final T defaultValue, final Class<T> valueClass) {
         final T converted = (this.extracted == null) ? defaultValue : convert(this.extracted.get(key), valueClass);
@@ -268,7 +268,7 @@ public class PifSearchHit {
      * @return Converted value.
      * @throws RuntimeException if the value cannot be converted.
      */
-    @JsonIgnore
+
     private <T extends Pio> T convert(final Object object, final Class<T> objectClass) {
         if (object == null) {
             return null;

--- a/src/main/java/io/citrine/jcc/search/pif/result/PifSearchResult.java
+++ b/src/main/java/io/citrine/jcc/search/pif/result/PifSearchResult.java
@@ -47,14 +47,14 @@ public class PifSearchResult extends BaseSearchResult<PifSearchHit> {
     }
 
     @Override
-    @JsonIgnore
+
     public PifSearchResult addHits(final List<PifSearchHit> hits) {
         super.addHits(hits);
         return this;
     }
 
     @Override
-    @JsonIgnore
+
     public PifSearchResult addHits(final PifSearchHit hits) {
         super.addHits(hits);
         return this;


### PR DESCRIPTION
@kjaym For some reason, 2.1.0 completely broke query de/serialization using scala object mappers. Is there an actual reason you put in all these @JsonIgnore annotations? My understanding is that @JsonIgnore indicates to jackson that it should ignore the _member_ not the _function_. This is at least how the scala mappers operate.

I have confirmed that queries de/serialize as expected w/ this version. 

cc: @maxhutch 