### PR TITLE
Add unwrap extractions option to PifSystemReturningQuery

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.citrine</groupId>
     <artifactId>jcc</artifactId>
-    <version>2.1.1</version>
+    <version>2.1.2</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/io/citrine/jcc/search/pif/query/PifSystemReturningQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/PifSystemReturningQuery.java
@@ -120,6 +120,28 @@ public class PifSystemReturningQuery extends BaseReturningQuery {
     }
 
     /**
+     * Set whether to unwrap single element extractions. This only applies when extractAll is true for an extraction
+     * and the outermost array only contains a single element.
+     *
+     * @param unwrapSingleValueExtractions True to unwrap single element extractions.
+     * @return This object.
+     */
+    public PifSystemReturningQuery setUnwrapSingleValueExtractions(final Boolean unwrapSingleValueExtractions) {
+        this.unwrapSingleValueExtractions = unwrapSingleValueExtractions;
+        return this;
+    }
+
+    /**
+     * Get whether to unwrap single element extractions. This only applies when extractAll is true for an extraction
+     * and the outermost array only contains a single element.
+     *
+     * @return True to unwrap single element extractions.
+     */
+    public Boolean getUnwrapSingleValueExtractions() {
+        return this.unwrapSingleValueExtractions;
+    }
+
+    /**
      * Deserialization of the system field from old PifQuery objects.
      *
      * @param system List of {@link PifSystemQuery} objects for the query.
@@ -170,4 +192,7 @@ public class PifSystemReturningQuery extends BaseReturningQuery {
 
     /** Whether to add latex formatting to results. */
     private Boolean addLatex;
+
+    /** Whether to unwrap single element arrays that are extracted. */
+    private Boolean unwrapSingleValueExtractions;
 }


### PR DESCRIPTION
This adds an option to PifSystemReturningQuery to unwrap single element extractions. This applies when extractAll is set to true on an extracted value and the resulting list only contains a single value.