### PR TITLE
Add simple search fields to all query objects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.citrine</groupId>
     <artifactId>jcc</artifactId>
-    <version>2.2.0</version>
+    <version>2.3.0</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/io/citrine/jcc/core/CitrinationClient.java
+++ b/src/main/java/io/citrine/jcc/core/CitrinationClient.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.citrine.jcc.search.core.query.MultiQuery;
-import io.citrine.jcc.search.core.query.MultiSearchResult;
+import io.citrine.jcc.search.core.result.MultiSearchResult;
 import io.citrine.jcc.search.pif.query.PifSystemReturningQuery;
 import io.citrine.jcc.search.pif.result.PifSearchResult;
 import org.apache.http.HttpResponse;

--- a/src/main/java/io/citrine/jcc/search/core/query/DataQuery.java
+++ b/src/main/java/io/citrine/jcc/search/core/query/DataQuery.java
@@ -25,6 +25,26 @@ public class DataQuery implements HasLogic {
     }
 
     /**
+     * Set the query to run against all fields.
+     *
+     * @param simple String with the query to run against all fields.
+     * @return This object.
+     */
+    public DataQuery setSimple(final String simple) {
+        this.simple = simple;
+        return this;
+    }
+
+    /**
+     * Get the query to run against all fields.
+     *
+     * @return String with the query to run against all fields.
+     */
+    public String getSimple() {
+        return this.simple;
+    }
+
+    /**
      * Set the list of dataset queries. This replaces any filters that are already present.
      *
      * @param dataset List of {@link DatasetQuery} objects.
@@ -166,6 +186,9 @@ public class DataQuery implements HasLogic {
 
     /** Logic for the query. */
     private Logic logic;
+
+    /** String with the simple search to run against all fields. */
+    private String simple;
 
     /** List of queries against dataset metadata. */
     private List<DatasetQuery> dataset;

--- a/src/main/java/io/citrine/jcc/search/core/result/MultiSearchResult.java
+++ b/src/main/java/io/citrine/jcc/search/core/result/MultiSearchResult.java
@@ -1,6 +1,5 @@
-package io.citrine.jcc.search.core.query;
+package io.citrine.jcc.search.core.result;
 
-import io.citrine.jcc.search.core.result.BaseSearchResult;
 import io.citrine.jcc.util.ListUtil;
 
 import java.util.Collections;

--- a/src/main/java/io/citrine/jcc/search/core/result/MultiSearchResultElement.java
+++ b/src/main/java/io/citrine/jcc/search/core/result/MultiSearchResultElement.java
@@ -1,4 +1,4 @@
-package io.citrine.jcc.search.core.query;
+package io.citrine.jcc.search.core.result;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;

--- a/src/main/java/io/citrine/jcc/search/dataset/query/DatasetQuery.java
+++ b/src/main/java/io/citrine/jcc/search/dataset/query/DatasetQuery.java
@@ -27,6 +27,26 @@ public class DatasetQuery implements HasLogic {
     }
 
     /**
+     * Set the query to run against all fields.
+     *
+     * @param simple String with the query to run against all fields.
+     * @return This object.
+     */
+    public DatasetQuery setSimple(final String simple) {
+        this.simple = simple;
+        return this;
+    }
+
+    /**
+     * Get the query to run against all fields.
+     *
+     * @return String with the query to run against all fields.
+     */
+    public String getSimple() {
+        return this.simple;
+    }
+
+    /**
      * Set the list of dataset ID queries. This replaces any filters that are already present.
      *
      * @param id List of {@link Filter} objects.
@@ -448,6 +468,9 @@ public class DatasetQuery implements HasLogic {
 
     /** Logic for the query. */
     private Logic logic;
+
+    /** String with the simple search to run against all fields. */
+    private String simple;
 
     /** List of filters against the dataset ID. */
     private List<Filter> id;

--- a/src/main/java/io/citrine/jcc/search/pif/query/PifSystemQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/PifSystemQuery.java
@@ -103,6 +103,26 @@ public class PifSystemQuery extends BaseObjectQuery {
     }
 
     /**
+     * Set the query to run against all fields.
+     *
+     * @param simple String with the query to run against all fields.
+     * @return This object.
+     */
+    public PifSystemQuery setSimple(final String simple) {
+        this.simple = simple;
+        return this;
+    }
+
+    /**
+     * Get the query to run against all fields.
+     *
+     * @return String with the query to run against all fields.
+     */
+    public String getSimple() {
+        return this.simple;
+    }
+
+    /**
      * Set the list of PIF system UID queries. This replaces any filters that are already present.
      *
      * @param uid List of {@link Filter} objects.
@@ -941,6 +961,9 @@ public class PifSystemQuery extends BaseObjectQuery {
     public List<PifSystemQuery> getSubSystems() {
         return this.subSystems;
     }
+
+    /** String with the simple search to run against all fields. */
+    private String simple;
 
     /** List of filters against the PIF system UID. */
     private List<Filter> uid;

--- a/src/main/java/io/citrine/jcc/search/pif/query/chemical/ChemicalFieldQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/chemical/ChemicalFieldQuery.java
@@ -22,6 +22,12 @@ public class ChemicalFieldQuery extends BaseFieldQuery implements HasChemicalFil
     }
 
     @Override
+    public ChemicalFieldQuery setSimple(final String simple) {
+        super.setSimple(simple);
+        return this;
+    }
+
+    @Override
     public ChemicalFieldQuery setExtractAs(final String extractAs) {
         super.setExtractAs(extractAs);
         return this;

--- a/src/main/java/io/citrine/jcc/search/pif/query/chemical/CompositionQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/chemical/CompositionQuery.java
@@ -93,6 +93,26 @@ public class CompositionQuery extends BaseObjectQuery {
     }
 
     /**
+     * Set the query to run against all fields.
+     *
+     * @param simple String with the query to run against all fields.
+     * @return This object.
+     */
+    public CompositionQuery setSimple(final String simple) {
+        this.simple = simple;
+        return this;
+    }
+
+    /**
+     * Get the query to run against all fields.
+     *
+     * @return String with the query to run against all fields.
+     */
+    public String getSimple() {
+        return this.simple;
+    }
+
+    /**
      * Set the element operations. This adds to any operations that are already saved.
      *
      * @param element List of {@link ChemicalFieldQuery} objects.
@@ -441,6 +461,9 @@ public class CompositionQuery extends BaseObjectQuery {
     public List<FieldQuery> getIdealAtomicPercent() {
         return this.idealAtomicPercent;
     }
+
+    /** String with the simple search to run against all fields. */
+    private String simple;
 
     /** Element for the composition. */
     private List<ChemicalFieldQuery> element;

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/BaseFieldQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/BaseFieldQuery.java
@@ -26,6 +26,26 @@ public abstract class BaseFieldQuery implements HasLogic {
     }
 
     /**
+     * Set the query to run against all fields.
+     *
+     * @param simple String with the query to run against all fields.
+     * @return This object.
+     */
+    public BaseFieldQuery setSimple(final String simple) {
+        this.simple = simple;
+        return this;
+    }
+
+    /**
+     * Get the query to run against all fields.
+     *
+     * @return String with the query to run against all fields.
+     */
+    public String getSimple() {
+        return this.simple;
+    }
+
+    /**
      * Set the alias to save this field under.
      *
      * @param extractAs String with the alias to save this field under.
@@ -228,6 +248,9 @@ public abstract class BaseFieldQuery implements HasLogic {
 
     /** Logic that applies to the entire query. */
     private Logic logic;
+
+    /** String with the simple search to run against all fields. */
+    private String simple;
 
     /** Alias to save this field under. */
     private String extractAs;

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/BaseObjectQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/BaseObjectQuery.java
@@ -25,6 +25,26 @@ public abstract class BaseObjectQuery implements HasLogic {
     }
 
     /**
+     * Set the query to run against all fields.
+     *
+     * @param simple String with the query to run against all fields.
+     * @return This object.
+     */
+    public BaseObjectQuery setSimple(final String simple) {
+        this.simple = simple;
+        return this;
+    }
+
+    /**
+     * Get the query to run against all fields.
+     *
+     * @return String with the query to run against all fields.
+     */
+    public String getSimple() {
+        return this.simple;
+    }
+
+    /**
      * Set the alias to save this field under.
      *
      * @param extractAs String with the alias to save this field under.
@@ -297,6 +317,9 @@ public abstract class BaseObjectQuery implements HasLogic {
 
     /** Logic that applies to the entire query. */
     private Logic logic;
+
+    /** String with the simple search to run against all fields. */
+    private String simple;
 
     /** Alias to save this field under. */
     private String extractAs;

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/ClassificationQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/ClassificationQuery.java
@@ -19,6 +19,12 @@ public class ClassificationQuery extends BaseObjectQuery {
     }
 
     @Override
+    public ClassificationQuery setSimple(final String simple) {
+        super.setSimple(simple);
+        return this;
+    }
+
+    @Override
     public ClassificationQuery setExtractAs(final String extractAs) {
         super.setExtractAs(extractAs);
         return this;

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/DisplayItemQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/DisplayItemQuery.java
@@ -18,6 +18,12 @@ public class DisplayItemQuery extends BaseObjectQuery {
     }
 
     @Override
+    public DisplayItemQuery setSimple(final String simple) {
+        super.setSimple(simple);
+        return this;
+    }
+
+    @Override
     public DisplayItemQuery setExtractAs(final String extractAs) {
         super.setExtractAs(extractAs);
         return this;

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/FieldQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/FieldQuery.java
@@ -22,6 +22,12 @@ public class FieldQuery extends BaseFieldQuery implements HasFilter {
     }
 
     @Override
+    public FieldQuery setSimple(final String simple) {
+        super.setSimple(simple);
+        return this;
+    }
+
+    @Override
     public FieldQuery setExtractAs(final String extractAs) {
         super.setExtractAs(extractAs);
         return this;

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/FileReferenceQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/FileReferenceQuery.java
@@ -19,6 +19,12 @@ public class FileReferenceQuery extends BaseObjectQuery {
     }
 
     @Override
+    public FileReferenceQuery setSimple(final String simple) {
+        super.setSimple(simple);
+        return this;
+    }
+
+    @Override
     public FileReferenceQuery setExtractAs(final String extractAs) {
         super.setExtractAs(extractAs);
         return this;

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/IdQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/IdQuery.java
@@ -19,6 +19,12 @@ public class IdQuery extends BaseObjectQuery {
     }
 
     @Override
+    public IdQuery setSimple(final String simple) {
+        super.setSimple(simple);
+        return this;
+    }
+
+    @Override
     public IdQuery setExtractAs(final String extractAs) {
         super.setExtractAs(extractAs);
         return this;

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/NameQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/NameQuery.java
@@ -19,6 +19,12 @@ public class NameQuery extends BaseObjectQuery {
     }
 
     @Override
+    public NameQuery setSimple(final String simple) {
+        super.setSimple(simple);
+        return this;
+    }
+
+    @Override
     public NameQuery setExtractAs(final String extractAs) {
         super.setExtractAs(extractAs);
         return this;

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/PagesQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/PagesQuery.java
@@ -1,7 +1,5 @@
 package io.citrine.jcc.search.pif.query.core;
 
-
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.citrine.jcc.search.core.query.Logic;
 import io.citrine.jcc.util.ListUtil;
 
@@ -17,6 +15,12 @@ public class PagesQuery extends BaseObjectQuery {
     @Override
     public PagesQuery setLogic(final Logic logic) {
         super.setLogic(logic);
+        return this;
+    }
+
+    @Override
+    public PagesQuery setSimple(final String simple) {
+        super.setSimple(simple);
         return this;
     }
 

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/ProcessStepQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/ProcessStepQuery.java
@@ -19,6 +19,12 @@ public class ProcessStepQuery extends BaseObjectQuery {
     }
 
     @Override
+    public ProcessStepQuery setSimple(final String simple) {
+        super.setSimple(simple);
+        return this;
+    }
+
+    @Override
     public ProcessStepQuery setExtractAs(final String extractAs) {
         super.setExtractAs(extractAs);
         return this;

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/PropertyQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/PropertyQuery.java
@@ -19,6 +19,12 @@ public class PropertyQuery extends ValueQuery {
     }
 
     @Override
+    public PropertyQuery setSimple(final String simple) {
+        super.setSimple(simple);
+        return this;
+    }
+
+    @Override
     public PropertyQuery setExtractAs(final String extractAs) {
         super.setExtractAs(extractAs);
         return this;

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/QuantityQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/QuantityQuery.java
@@ -19,6 +19,12 @@ public class QuantityQuery extends BaseObjectQuery {
     }
 
     @Override
+    public QuantityQuery setSimple(final String simple) {
+        super.setSimple(simple);
+        return this;
+    }
+
+    @Override
     public QuantityQuery setExtractAs(final String extractAs) {
         super.setExtractAs(extractAs);
         return this;

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/ReferenceQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/ReferenceQuery.java
@@ -19,6 +19,12 @@ public class ReferenceQuery extends BaseObjectQuery {
     }
 
     @Override
+    public ReferenceQuery setSimple(final String simple) {
+        super.setSimple(simple);
+        return this;
+    }
+
+    @Override
     public ReferenceQuery setExtractAs(final String extractAs) {
         super.setExtractAs(extractAs);
         return this;

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/SourceQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/SourceQuery.java
@@ -19,6 +19,12 @@ public class SourceQuery extends BaseObjectQuery {
     }
 
     @Override
+    public SourceQuery setSimple(final String simple) {
+        super.setSimple(simple);
+        return this;
+    }
+
+    @Override
     public SourceQuery setExtractAs(final String extractAs) {
         super.setExtractAs(extractAs);
         return this;

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/ValueQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/ValueQuery.java
@@ -19,6 +19,12 @@ public class ValueQuery extends BaseObjectQuery {
     }
 
     @Override
+    public ValueQuery setSimple(final String simple) {
+        super.setSimple(simple);
+        return this;
+    }
+
+    @Override
     public ValueQuery setExtractAs(final String extractAs) {
         super.setExtractAs(extractAs);
         return this;


### PR DESCRIPTION
The simple search field is meant to store a string that will be tokenized and filtered over all fields in the current object and its children. For example, a simple search at the root DataQuery level would search over all datasets (name, description, etc) and all of the fields in the PIF. If the simple search field is filled out on say a ProcessStep object, then it will execute against the name of the process step and all of the nested objects.