### PR TITLE
Feature/sorting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.citrine</groupId>
     <artifactId>jcc</artifactId>
-    <version>2.4.0</version>
+    <version>2.5.0</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/io/citrine/jcc/search/core/query/BaseReturningQuery.java
+++ b/src/main/java/io/citrine/jcc/search/core/query/BaseReturningQuery.java
@@ -30,6 +30,12 @@ public abstract class BaseReturningQuery extends DataScope {
         return this;
     }
 
+    @Override
+    public BaseReturningQuery setExtractionSort(final ExtractionSort extractionSort) {
+        super.setExtractionSort(extractionSort);
+        return this;
+    }
+
     /**
      * Index of the first hit that should be returned. This method is here just to be compatible with the python
      * client.

--- a/src/main/java/io/citrine/jcc/search/core/query/DataScope.java
+++ b/src/main/java/io/citrine/jcc/search/core/query/DataScope.java
@@ -81,7 +81,30 @@ public class DataScope {
         return this.query;
     }
 
+    /**
+     * Sort to apply on an extracted field.
+     *
+     * @param extractionSort {@link ExtractionSort} to apply.
+     * @return This object.
+     */
+    public DataScope setExtractionSort(final ExtractionSort extractionSort) {
+        this.extractionSort = extractionSort;
+        return this;
+    }
+
+    /**
+     * Get the sort order on an extracted field.
+     *
+     * @return {@link ExtractionSort} to use.
+     */
+    public ExtractionSort getExtractionSort() {
+        return this.extractionSort;
+    }
+
     /** List of queries against the content of datasets. */
     private List<DataQuery> query;
+
+    /** Sort to apply on an extracted field. */
+    private ExtractionSort extractionSort;
 }
 

--- a/src/main/java/io/citrine/jcc/search/core/query/ExtractionSort.java
+++ b/src/main/java/io/citrine/jcc/search/core/query/ExtractionSort.java
@@ -1,0 +1,55 @@
+package io.citrine.jcc.search.core.query;
+
+/**
+ * Definition of a sort operation on an extraction within a query.
+ *
+ * @author Kyle Michel
+ */
+public class ExtractionSort {
+
+    /**
+     * Set the key that will be sorted on.
+     *
+     * @param key String with the key that will be sorted on.
+     * @return This object.
+     */
+    public ExtractionSort setKey(final String key) {
+        this.key = key;
+        return this;
+    }
+
+    /**
+     * Get the key that will be sorted on.
+     *
+     * @return String with the key that will be sorted on.
+     */
+    public String getKey() {
+        return this.key;
+    }
+
+    /**
+     * Set the sort order.
+     *
+     * @param order {@link SortOrder} to use.
+     * @return This object.
+     */
+    public ExtractionSort setOrder(final SortOrder order) {
+        this.order = order;
+        return this;
+    }
+
+    /**
+     * Get the sort order to use.
+     *
+     * @return {@link SortOrder} to use.
+     */
+    public SortOrder getOrder() {
+        return this.order;
+    }
+
+    /** The extractAs key to sort on. */
+    private String key;
+
+    /** The order to sort. */
+    private SortOrder order;
+}

--- a/src/main/java/io/citrine/jcc/search/core/query/SortOrder.java
+++ b/src/main/java/io/citrine/jcc/search/core/query/SortOrder.java
@@ -1,0 +1,15 @@
+package io.citrine.jcc.search.core.query;
+
+/**
+ * The sort order to use for a field.
+ *
+ * @author Kyle Michel
+ */
+public enum SortOrder {
+
+    /** Sort in ascending order. */
+    ASCENDING,
+
+    /** Sort in descending order. */
+    DESCENDING
+}

--- a/src/main/java/io/citrine/jcc/search/dataset/query/DatasetReturningQuery.java
+++ b/src/main/java/io/citrine/jcc/search/dataset/query/DatasetReturningQuery.java
@@ -3,6 +3,7 @@ package io.citrine.jcc.search.dataset.query;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import io.citrine.jcc.search.core.query.BaseReturningQuery;
 import io.citrine.jcc.search.core.query.DataQuery;
+import io.citrine.jcc.search.core.query.ExtractionSort;
 import io.citrine.jcc.search.core.query.Logic;
 import io.citrine.jcc.search.pif.query.PifSystemQuery;
 
@@ -73,6 +74,12 @@ public class DatasetReturningQuery extends BaseReturningQuery {
     @Override
     public DatasetReturningQuery addQuery(final DataQuery query) {
         super.addQuery(query);
+        return this;
+    }
+
+    @Override
+    public DatasetReturningQuery setExtractionSort(final ExtractionSort extractionSort) {
+        super.setExtractionSort(extractionSort);
         return this;
     }
 

--- a/src/main/java/io/citrine/jcc/search/pif/query/PifSystemQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/PifSystemQuery.java
@@ -31,6 +31,12 @@ public class PifSystemQuery extends BaseObjectQuery {
     }
 
     @Override
+    public PifSystemQuery setSimple(final String simple) {
+        super.setSimple(simple);
+        return this;
+    }
+
+    @Override
     public PifSystemQuery setExtractAs(final String extractAs) {
         super.setExtractAs(extractAs);
         return this;
@@ -100,26 +106,6 @@ public class PifSystemQuery extends BaseObjectQuery {
     public PifSystemQuery addOffset(final FieldQuery offset) {
         super.addOffset(offset);
         return this;
-    }
-
-    /**
-     * Set the query to run against all fields.
-     *
-     * @param simple String with the query to run against all fields.
-     * @return This object.
-     */
-    public PifSystemQuery setSimple(final String simple) {
-        this.simple = simple;
-        return this;
-    }
-
-    /**
-     * Get the query to run against all fields.
-     *
-     * @return String with the query to run against all fields.
-     */
-    public String getSimple() {
-        return this.simple;
     }
 
     /**
@@ -1031,9 +1017,6 @@ public class PifSystemQuery extends BaseObjectQuery {
     public List<PifSystemQuery> getQuery() {
         return this.query;
     }
-
-    /** String with the simple search to run against all fields. */
-    private String simple;
 
     /** List of filters against the PIF system UID. */
     private List<Filter> uid;

--- a/src/main/java/io/citrine/jcc/search/pif/query/PifSystemReturningQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/PifSystemReturningQuery.java
@@ -3,6 +3,7 @@ package io.citrine.jcc.search.pif.query;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import io.citrine.jcc.search.core.query.BaseReturningQuery;
 import io.citrine.jcc.search.core.query.DataQuery;
+import io.citrine.jcc.search.core.query.ExtractionSort;
 import io.citrine.jcc.search.core.query.Filter;
 import io.citrine.jcc.search.core.query.Logic;
 import io.citrine.jcc.search.dataset.query.DatasetQuery;
@@ -75,6 +76,12 @@ public class PifSystemReturningQuery extends BaseReturningQuery {
     @Override
     public PifSystemReturningQuery addQuery(final DataQuery query) {
         super.addQuery(query);
+        return this;
+    }
+
+    @Override
+    public PifSystemReturningQuery setExtractionSort(final ExtractionSort extractionSort) {
+        super.setExtractionSort(extractionSort);
         return this;
     }
 

--- a/src/main/java/io/citrine/jcc/search/pif/query/chemical/ChemicalFieldQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/chemical/ChemicalFieldQuery.java
@@ -2,6 +2,7 @@ package io.citrine.jcc.search.pif.query.chemical;
 
 import com.fasterxml.jackson.annotation.JsonSetter;
 import io.citrine.jcc.search.core.query.Logic;
+import io.citrine.jcc.search.core.query.SortOrder;
 import io.citrine.jcc.search.pif.query.core.BaseFieldQuery;
 import io.citrine.jcc.search.pif.query.core.FieldQuery;
 import io.citrine.jcc.util.ListUtil;
@@ -18,6 +19,12 @@ public class ChemicalFieldQuery extends BaseFieldQuery implements HasChemicalFil
     @Override
     public ChemicalFieldQuery setLogic(final Logic logic) {
         super.setLogic(logic);
+        return this;
+    }
+
+    @Override
+    public ChemicalFieldQuery setSort(final SortOrder sort) {
+        super.setSort(sort);
         return this;
     }
 

--- a/src/main/java/io/citrine/jcc/search/pif/query/chemical/CompositionQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/chemical/CompositionQuery.java
@@ -21,6 +21,12 @@ public class CompositionQuery extends BaseObjectQuery {
     }
 
     @Override
+    public CompositionQuery setSimple(final String simple) {
+        super.setSimple(simple);
+        return this;
+    }
+
+    @Override
     public CompositionQuery setExtractAs(final String extractAs) {
         super.setExtractAs(extractAs);
         return this;
@@ -90,26 +96,6 @@ public class CompositionQuery extends BaseObjectQuery {
     public CompositionQuery addOffset(final FieldQuery offset) {
         super.addOffset(offset);
         return this;
-    }
-
-    /**
-     * Set the query to run against all fields.
-     *
-     * @param simple String with the query to run against all fields.
-     * @return This object.
-     */
-    public CompositionQuery setSimple(final String simple) {
-        this.simple = simple;
-        return this;
-    }
-
-    /**
-     * Get the query to run against all fields.
-     *
-     * @return String with the query to run against all fields.
-     */
-    public String getSimple() {
-        return this.simple;
     }
 
     /**
@@ -531,9 +517,6 @@ public class CompositionQuery extends BaseObjectQuery {
     public List<CompositionQuery> getQuery() {
         return this.query;
     }
-
-    /** String with the simple search to run against all fields. */
-    private String simple;
 
     /** Element for the composition. */
     private List<ChemicalFieldQuery> element;

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/BaseFieldQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/BaseFieldQuery.java
@@ -2,6 +2,7 @@ package io.citrine.jcc.search.pif.query.core;
 
 import io.citrine.jcc.search.core.query.HasLogic;
 import io.citrine.jcc.search.core.query.Logic;
+import io.citrine.jcc.search.core.query.SortOrder;
 import io.citrine.jcc.util.ListUtil;
 
 import java.util.List;
@@ -23,6 +24,26 @@ public abstract class BaseFieldQuery implements HasLogic {
     @Override
     public Logic getLogic() {
         return this.logic;
+    }
+
+    /**
+     * Set the sort order to use.
+     *
+     * @param sort {@link SortOrder} to apply to the field.
+     * @return This object.
+     */
+    public BaseFieldQuery setSort(final SortOrder sort) {
+        this.sort = sort;
+        return this;
+    }
+
+    /**
+     * Get the sort order to use.
+     *
+     * @return {@link SortOrder} to use.
+     */
+    public SortOrder getSort() {
+        return this.sort;
     }
 
     /**
@@ -245,6 +266,9 @@ public abstract class BaseFieldQuery implements HasLogic {
     public List<FieldQuery> getOffset() {
         return this.offset;
     }
+
+    /** The sort order to apply to the field. */
+    private SortOrder sort;
 
     /** Logic that applies to the entire query. */
     private Logic logic;

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/FieldQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/FieldQuery.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonSetter;
 import io.citrine.jcc.search.core.query.Filter;
 import io.citrine.jcc.search.core.query.HasFilter;
 import io.citrine.jcc.search.core.query.Logic;
+import io.citrine.jcc.search.core.query.SortOrder;
 import io.citrine.jcc.util.ListUtil;
 
 import java.util.List;
@@ -18,6 +19,12 @@ public class FieldQuery extends BaseFieldQuery implements HasFilter {
     @Override
     public FieldQuery setLogic(final Logic logic) {
         super.setLogic(logic);
+        return this;
+    }
+
+    @Override
+    public FieldQuery setSort(final SortOrder sort) {
+        super.setSort(sort);
         return this;
     }
 


### PR DESCRIPTION
This adds support for sorting in two places. In the first, a use can add to any FieldQuery-type object a sort order - either ASCENDING or DESCENDING. This will allow for sorting on any field within a PIF. In the second, a user can specify at the top level of a query the extractAs key and sort order if sorted on an extracted value. This is a convenience method that can be used to sort dynamically based on extraction keys, rather than having to inject into a specific location in the PIF.

This also sneaks in a fix in a couple places where we were calling setSimple to set the simple search string rather than overriding the method from its super class. 