### PR TITLE
2.5.1: move extractionSort

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.citrine</groupId>
     <artifactId>jcc</artifactId>
-    <version>2.5.0</version>
+    <version>2.5.1</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/io/citrine/jcc/search/core/query/BaseReturningQuery.java
+++ b/src/main/java/io/citrine/jcc/search/core/query/BaseReturningQuery.java
@@ -30,12 +30,6 @@ public abstract class BaseReturningQuery extends DataScope {
         return this;
     }
 
-    @Override
-    public BaseReturningQuery setExtractionSort(final ExtractionSort extractionSort) {
-        super.setExtractionSort(extractionSort);
-        return this;
-    }
-
     /**
      * Index of the first hit that should be returned. This method is here just to be compatible with the python
      * client.
@@ -181,6 +175,26 @@ public abstract class BaseReturningQuery extends DataScope {
         return this.returnMaxScore;
     }
 
+    /**
+     * Sort to apply on an extracted field.
+     *
+     * @param extractionSort {@link ExtractionSort} to apply.
+     * @return This object.
+     */
+    public DataScope setExtractionSort(final ExtractionSort extractionSort) {
+        this.extractionSort = extractionSort;
+        return this;
+    }
+
+    /**
+     * Get the sort order on an extracted field.
+     *
+     * @return {@link ExtractionSort} to use.
+     */
+    public ExtractionSort getExtractionSort() {
+        return this.extractionSort;
+    }
+
     /** Index of the first hit that should be returned. */
     private Integer from;
 
@@ -198,4 +212,7 @@ public abstract class BaseReturningQuery extends DataScope {
 
     /** Whether to return the maximum score. */
     private Boolean returnMaxScore;
+
+    /** Sort to apply on an extracted field. */
+    private ExtractionSort extractionSort;
 }

--- a/src/main/java/io/citrine/jcc/search/core/query/DataScope.java
+++ b/src/main/java/io/citrine/jcc/search/core/query/DataScope.java
@@ -81,30 +81,7 @@ public class DataScope {
         return this.query;
     }
 
-    /**
-     * Sort to apply on an extracted field.
-     *
-     * @param extractionSort {@link ExtractionSort} to apply.
-     * @return This object.
-     */
-    public DataScope setExtractionSort(final ExtractionSort extractionSort) {
-        this.extractionSort = extractionSort;
-        return this;
-    }
-
-    /**
-     * Get the sort order on an extracted field.
-     *
-     * @return {@link ExtractionSort} to use.
-     */
-    public ExtractionSort getExtractionSort() {
-        return this.extractionSort;
-    }
-
     /** List of queries against the content of datasets. */
     private List<DataQuery> query;
-
-    /** Sort to apply on an extracted field. */
-    private ExtractionSort extractionSort;
 }
 


### PR DESCRIPTION
Just moving set(get)ExtractionSort from DataScope to BaseReturningQuery, which is a more appropriate place for it.