### PR TITLE
Feature/weights

### DIFF
--- a/src/main/java/io/citrine/jcc/search/core/query/BooleanFilter.java
+++ b/src/main/java/io/citrine/jcc/search/core/query/BooleanFilter.java
@@ -11,7 +11,7 @@ import java.util.Optional;
  * 
  * @author Kyle Michel
  */
-public class BooleanFilter implements HasLogic {
+public class BooleanFilter implements HasLogic, HasWeight {
 
     @Override
     public BooleanFilter setLogic(final Logic logic) {
@@ -22,6 +22,17 @@ public class BooleanFilter implements HasLogic {
     @Override
     public Logic getLogic() {
         return this.logic;
+    }
+
+    @Override
+    public BooleanFilter setWeight(final Double weight) {
+        this.weight = weight;
+        return this;
+    }
+
+    @Override
+    public Double getWeight() {
+        return this.weight;
     }
 
     /**
@@ -161,6 +172,9 @@ public class BooleanFilter implements HasLogic {
 
     /** Logic for applying the filters. */
     private Logic logic;
+
+    /** Weight of the filter. */
+    private Double weight;
 
     /** Just check for existence. */
     private Boolean exists;

--- a/src/main/java/io/citrine/jcc/search/core/query/DataQuery.java
+++ b/src/main/java/io/citrine/jcc/search/core/query/DataQuery.java
@@ -368,7 +368,9 @@ public class DataQuery implements HasLogic, HasWeight {
         }
         final DataQuery rhsQuery = (DataQuery) rhs;
         return Optional.ofNullable(this.logic).equals(Optional.ofNullable(rhsQuery.logic))
+                && Optional.ofNullable(this.weight).equals(Optional.ofNullable(rhsQuery.weight))
                 && Optional.ofNullable(this.simple).equals(Optional.ofNullable(rhsQuery.simple))
+                && Optional.ofNullable(this.simpleWeight).equals(Optional.ofNullable(rhsQuery.simpleWeight))
                 && Optional.ofNullable(this.dataset).equals(Optional.ofNullable(rhsQuery.dataset))
                 && Optional.ofNullable(this.system).equals(Optional.ofNullable(rhsQuery.system))
                 && Optional.ofNullable(this.file).equals(Optional.ofNullable(rhsQuery.file))

--- a/src/main/java/io/citrine/jcc/search/core/query/DataQuery.java
+++ b/src/main/java/io/citrine/jcc/search/core/query/DataQuery.java
@@ -4,6 +4,7 @@ import io.citrine.jcc.search.dataset.query.DatasetQuery;
 import io.citrine.jcc.search.file.query.FileQuery;
 import io.citrine.jcc.search.pif.query.PifSystemQuery;
 import io.citrine.jcc.util.ListUtil;
+import io.citrine.jcc.util.MapUtil;
 
 import java.util.List;
 import java.util.Map;
@@ -52,6 +53,18 @@ public class DataQuery implements HasLogic, HasWeight, HasSimple {
     @Override
     public DataQuery setSimpleWeight(final Map<String, Double> simpleWeight) {
         this.simpleWeight = simpleWeight;
+        return this;
+    }
+
+    @Override
+    public DataQuery addSimpleWeight(final Map<String, Double> simpleWeight) {
+        this.simpleWeight = MapUtil.add(simpleWeight, this.simpleWeight);
+        return this;
+    }
+
+    @Override
+    public DataQuery addSimpleWeight(final String field, final Double weight) {
+        this.simpleWeight = MapUtil.add(field, weight, this.simpleWeight);
         return this;
     }
 

--- a/src/main/java/io/citrine/jcc/search/core/query/DataQuery.java
+++ b/src/main/java/io/citrine/jcc/search/core/query/DataQuery.java
@@ -14,7 +14,7 @@ import java.util.Optional;
  *
  * @author Kyle Michel
  */
-public class DataQuery implements HasLogic, HasWeight {
+public class DataQuery implements HasLogic, HasWeight, HasSimple {
 
     @Override
     public DataQuery setLogic(final Logic logic) {
@@ -38,42 +38,24 @@ public class DataQuery implements HasLogic, HasWeight {
         return this.weight;
     }
 
-    /**
-     * Set the query to run against all fields.
-     *
-     * @param simple String with the query to run against all fields.
-     * @return This object.
-     */
+    @Override
     public DataQuery setSimple(final String simple) {
         this.simple = simple;
         return this;
     }
 
-    /**
-     * Get the query to run against all fields.
-     *
-     * @return String with the query to run against all fields.
-     */
+    @Override
     public String getSimple() {
         return this.simple;
     }
 
-    /**
-     * Set the map of relative field paths to their weights for simple queries.
-     *
-     * @param simpleWeight Map of field paths to weights.
-     * @return This object.
-     */
+    @Override
     public DataQuery setSimpleWeight(final Map<String, Double> simpleWeight) {
         this.simpleWeight = simpleWeight;
         return this;
     }
 
-    /**
-     * Get the map of relative field paths to their weights for simple queries.
-     *
-     * @return Map of field paths to weights.
-     */
+    @Override
     public Map<String, Double> getSimpleWeight() {
         return this.simpleWeight;
     }

--- a/src/main/java/io/citrine/jcc/search/core/query/DataQuery.java
+++ b/src/main/java/io/citrine/jcc/search/core/query/DataQuery.java
@@ -6,6 +6,7 @@ import io.citrine.jcc.search.pif.query.PifSystemQuery;
 import io.citrine.jcc.util.ListUtil;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -55,6 +56,26 @@ public class DataQuery implements HasLogic, HasWeight {
      */
     public String getSimple() {
         return this.simple;
+    }
+
+    /**
+     * Set the map of relative field paths to their weights for simple queries.
+     *
+     * @param simpleWeight Map of field paths to weights.
+     * @return This object.
+     */
+    public DataQuery setSimpleWeight(final Map<String, Double> simpleWeight) {
+        this.simpleWeight = simpleWeight;
+        return this;
+    }
+
+    /**
+     * Get the map of relative field paths to their weights for simple queries.
+     *
+     * @return Map of field paths to weights.
+     */
+    public Map<String, Double> getSimpleWeight() {
+        return this.simpleWeight;
     }
 
     /**
@@ -362,6 +383,9 @@ public class DataQuery implements HasLogic, HasWeight {
 
     /** String with the simple search to run against all fields. */
     private String simple;
+
+    /** Map of field names to weights for the simple search string. */
+    private Map<String, Double> simpleWeight;
 
     /** List of queries against dataset metadata. */
     private List<DatasetQuery> dataset;

--- a/src/main/java/io/citrine/jcc/search/core/query/DataQuery.java
+++ b/src/main/java/io/citrine/jcc/search/core/query/DataQuery.java
@@ -13,7 +13,7 @@ import java.util.Optional;
  *
  * @author Kyle Michel
  */
-public class DataQuery implements HasLogic {
+public class DataQuery implements HasLogic, HasWeight {
 
     @Override
     public DataQuery setLogic(final Logic logic) {
@@ -24,6 +24,17 @@ public class DataQuery implements HasLogic {
     @Override
     public Logic getLogic() {
         return this.logic;
+    }
+
+    @Override
+    public DataQuery setWeight(final Double weight) {
+        this.weight = weight;
+        return this;
+    }
+
+    @Override
+    public Double getWeight() {
+        return this.weight;
     }
 
     /**
@@ -345,6 +356,9 @@ public class DataQuery implements HasLogic {
 
     /** Logic for the query. */
     private Logic logic;
+
+    /** Weight of the query. */
+    private Double weight;
 
     /** String with the simple search to run against all fields. */
     private String simple;

--- a/src/main/java/io/citrine/jcc/search/core/query/Filter.java
+++ b/src/main/java/io/citrine/jcc/search/core/query/Filter.java
@@ -13,7 +13,7 @@ import java.util.Optional;
  * 
  * @author Kyle Michel
  */
-public class Filter implements HasLogic, HasFilter {
+public class Filter implements HasLogic, HasWeight, HasFilter {
 
     @Override
     public Filter setLogic(final Logic logic) {
@@ -24,6 +24,17 @@ public class Filter implements HasLogic, HasFilter {
     @Override
     public Logic getLogic() {
         return this.logic;
+    }
+
+    @Override
+    public Filter setWeight(final Double weight) {
+        this.weight = weight;
+        return this;
+    }
+
+    @Override
+    public Double getWeight() {
+        return this.weight;
     }
 
     @Override
@@ -285,6 +296,9 @@ public class Filter implements HasLogic, HasFilter {
 
     /** Logic for applying the filter. */
     private Logic logic;
+
+    /** Weight of the filter. */
+    private Double weight;
 
     /** Just check for existence. */
     private Boolean exists;

--- a/src/main/java/io/citrine/jcc/search/core/query/Filter.java
+++ b/src/main/java/io/citrine/jcc/search/core/query/Filter.java
@@ -286,6 +286,7 @@ public class Filter implements HasLogic, HasWeight, HasFilter {
         }
         final Filter rhsFilter = (Filter) rhs;
         return Optional.ofNullable(this.logic).equals(Optional.ofNullable(rhsFilter.logic))
+                && Optional.ofNullable(this.weight).equals(Optional.ofNullable(rhsFilter.weight))
                 && Optional.ofNullable(this.exists).equals(Optional.ofNullable(rhsFilter.exists))
                 && Optional.ofNullable(this.equal).equals(Optional.ofNullable(rhsFilter.equal))
                 && Optional.ofNullable(this.min).equals(Optional.ofNullable(rhsFilter.min))

--- a/src/main/java/io/citrine/jcc/search/core/query/HasSimple.java
+++ b/src/main/java/io/citrine/jcc/search/core/query/HasSimple.java
@@ -1,0 +1,41 @@
+package io.citrine.jcc.search.core.query;
+
+import java.util.Map;
+
+/**
+ * Interface for classes that have simple queries and weights for those queries.
+ *
+ * @author Kyle Michel
+ */
+public interface HasSimple {
+
+    /**
+     * Set the query to run against all fields.
+     *
+     * @param simple String with the query to run against all fields.
+     * @return This object.
+     */
+    HasSimple setSimple(final String simple);
+
+    /**
+     * Get the query to run against all fields.
+     *
+     * @return String with the query to run against all fields.
+     */
+    String getSimple();
+
+    /**
+     * Set the map of relative field paths to their weights for simple queries.
+     *
+     * @param simpleWeight Map of field paths to weights.
+     * @return This object.
+     */
+    HasSimple setSimpleWeight(final Map<String, Double> simpleWeight);
+
+    /**
+     * Get the map of relative field paths to their weights for simple queries.
+     *
+     * @return Map of field paths to weights.
+     */
+    Map<String, Double> getSimpleWeight();
+}

--- a/src/main/java/io/citrine/jcc/search/core/query/HasSimple.java
+++ b/src/main/java/io/citrine/jcc/search/core/query/HasSimple.java
@@ -33,6 +33,23 @@ public interface HasSimple {
     HasSimple setSimpleWeight(final Map<String, Double> simpleWeight);
 
     /**
+     * Add a single weight to simple queries.
+     *
+     * @param field Name of the field.
+     * @param weight Weight for the query on the field.
+     * @return This object.
+     */
+    HasSimple addSimpleWeight(final String field, final Double weight);
+
+    /**
+     * Add all in a map of weights for simple queries.
+     *
+     * @param simpleWeight Map of field names to weights.
+     * @return This object.
+     */
+    HasSimple addSimpleWeight(final Map<String, Double> simpleWeight);
+
+    /**
      * Get the map of relative field paths to their weights for simple queries.
      *
      * @return Map of field paths to weights.

--- a/src/main/java/io/citrine/jcc/search/core/query/HasWeight.java
+++ b/src/main/java/io/citrine/jcc/search/core/query/HasWeight.java
@@ -1,0 +1,24 @@
+package io.citrine.jcc.search.core.query;
+
+/**
+ * Interface for classes that have scoring weights associated with them.
+ *
+ * @author Kyle Michel
+ */
+public interface HasWeight {
+
+    /**
+     * Set the weight of the operation.
+     *
+     * @param weight Weight to apply.
+     * @return This object.
+     */
+    HasWeight setWeight(final Double weight);
+
+    /**
+     * Get the weight of the operation.
+     *
+     * @return Double with the weight or a null pointer if it has not been set.
+     */
+    Double getWeight();
+}

--- a/src/main/java/io/citrine/jcc/search/dataset/query/DatasetQuery.java
+++ b/src/main/java/io/citrine/jcc/search/dataset/query/DatasetQuery.java
@@ -3,6 +3,7 @@ package io.citrine.jcc.search.dataset.query;
 import io.citrine.jcc.search.core.query.BooleanFilter;
 import io.citrine.jcc.search.core.query.Filter;
 import io.citrine.jcc.search.core.query.HasLogic;
+import io.citrine.jcc.search.core.query.HasSimple;
 import io.citrine.jcc.search.core.query.HasWeight;
 import io.citrine.jcc.search.core.query.Logic;
 import io.citrine.jcc.util.ListUtil;
@@ -16,7 +17,7 @@ import java.util.Optional;
  *
  * @author Kyle Michel
  */
-public class DatasetQuery implements HasLogic, HasWeight {
+public class DatasetQuery implements HasLogic, HasWeight, HasSimple {
 
     @Override
     public DatasetQuery setLogic(final Logic logic) {
@@ -40,42 +41,24 @@ public class DatasetQuery implements HasLogic, HasWeight {
         return this.weight;
     }
 
-    /**
-     * Set the query to run against all fields.
-     *
-     * @param simple String with the query to run against all fields.
-     * @return This object.
-     */
+    @Override
     public DatasetQuery setSimple(final String simple) {
         this.simple = simple;
         return this;
     }
 
-    /**
-     * Get the query to run against all fields.
-     *
-     * @return String with the query to run against all fields.
-     */
+    @Override
     public String getSimple() {
         return this.simple;
     }
 
-    /**
-     * Set the map of relative field paths to their weights for simple queries.
-     *
-     * @param simpleWeight Map of field paths to weights.
-     * @return This object.
-     */
+    @Override
     public DatasetQuery setSimpleWeight(final Map<String, Double> simpleWeight) {
         this.simpleWeight = simpleWeight;
         return this;
     }
 
-    /**
-     * Get the map of relative field paths to their weights for simple queries.
-     *
-     * @return Map of field paths to weights.
-     */
+    @Override
     public Map<String, Double> getSimpleWeight() {
         return this.simpleWeight;
     }

--- a/src/main/java/io/citrine/jcc/search/dataset/query/DatasetQuery.java
+++ b/src/main/java/io/citrine/jcc/search/dataset/query/DatasetQuery.java
@@ -8,6 +8,7 @@ import io.citrine.jcc.search.core.query.Logic;
 import io.citrine.jcc.util.ListUtil;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -57,6 +58,26 @@ public class DatasetQuery implements HasLogic, HasWeight {
      */
     public String getSimple() {
         return this.simple;
+    }
+
+    /**
+     * Set the map of relative field paths to their weights for simple queries.
+     *
+     * @param simpleWeight Map of field paths to weights.
+     * @return This object.
+     */
+    public DatasetQuery setSimpleWeight(final Map<String, Double> simpleWeight) {
+        this.simpleWeight = simpleWeight;
+        return this;
+    }
+
+    /**
+     * Get the map of relative field paths to their weights for simple queries.
+     *
+     * @return Map of field paths to weights.
+     */
+    public Map<String, Double> getSimpleWeight() {
+        return this.simpleWeight;
     }
 
     /**
@@ -648,6 +669,9 @@ public class DatasetQuery implements HasLogic, HasWeight {
 
     /** String with the simple search to run against all fields. */
     private String simple;
+
+    /** Map of field names to weights for the simple search string. */
+    private Map<String, Double> simpleWeight;
 
     /** List of filters against the dataset ID. */
     private List<Filter> id;

--- a/src/main/java/io/citrine/jcc/search/dataset/query/DatasetQuery.java
+++ b/src/main/java/io/citrine/jcc/search/dataset/query/DatasetQuery.java
@@ -3,6 +3,7 @@ package io.citrine.jcc.search.dataset.query;
 import io.citrine.jcc.search.core.query.BooleanFilter;
 import io.citrine.jcc.search.core.query.Filter;
 import io.citrine.jcc.search.core.query.HasLogic;
+import io.citrine.jcc.search.core.query.HasWeight;
 import io.citrine.jcc.search.core.query.Logic;
 import io.citrine.jcc.util.ListUtil;
 
@@ -14,7 +15,7 @@ import java.util.Optional;
  *
  * @author Kyle Michel
  */
-public class DatasetQuery implements HasLogic {
+public class DatasetQuery implements HasLogic, HasWeight {
 
     @Override
     public DatasetQuery setLogic(final Logic logic) {
@@ -25,6 +26,17 @@ public class DatasetQuery implements HasLogic {
     @Override
     public Logic getLogic() {
         return this.logic;
+    }
+
+    @Override
+    public DatasetQuery setWeight(final Double weight) {
+        this.weight = weight;
+        return this;
+    }
+
+    @Override
+    public Double getWeight() {
+        return this.weight;
     }
 
     /**
@@ -630,6 +642,9 @@ public class DatasetQuery implements HasLogic {
 
     /** Logic for the query. */
     private Logic logic;
+
+    /** Weight of the query. */
+    private Double weight;
 
     /** String with the simple search to run against all fields. */
     private String simple;

--- a/src/main/java/io/citrine/jcc/search/dataset/query/DatasetQuery.java
+++ b/src/main/java/io/citrine/jcc/search/dataset/query/DatasetQuery.java
@@ -7,6 +7,7 @@ import io.citrine.jcc.search.core.query.HasSimple;
 import io.citrine.jcc.search.core.query.HasWeight;
 import io.citrine.jcc.search.core.query.Logic;
 import io.citrine.jcc.util.ListUtil;
+import io.citrine.jcc.util.MapUtil;
 
 import java.util.List;
 import java.util.Map;
@@ -55,6 +56,18 @@ public class DatasetQuery implements HasLogic, HasWeight, HasSimple {
     @Override
     public DatasetQuery setSimpleWeight(final Map<String, Double> simpleWeight) {
         this.simpleWeight = simpleWeight;
+        return this;
+    }
+
+    @Override
+    public DatasetQuery addSimpleWeight(final Map<String, Double> simpleWeight) {
+        this.simpleWeight = MapUtil.add(simpleWeight, this.simpleWeight);
+        return this;
+    }
+
+    @Override
+    public DatasetQuery addSimpleWeight(final String field, final Double weight) {
+        this.simpleWeight = MapUtil.add(field, weight, this.simpleWeight);
         return this;
     }
 

--- a/src/main/java/io/citrine/jcc/search/dataset/query/DatasetQuery.java
+++ b/src/main/java/io/citrine/jcc/search/dataset/query/DatasetQuery.java
@@ -650,7 +650,9 @@ public class DatasetQuery implements HasLogic, HasWeight {
         }
         final DatasetQuery rhsQuery = (DatasetQuery) rhs;
         return Optional.ofNullable(this.logic).equals(Optional.ofNullable(rhsQuery.logic))
+                && Optional.ofNullable(this.weight).equals(Optional.ofNullable(rhsQuery.weight))
                 && Optional.ofNullable(this.simple).equals(Optional.ofNullable(rhsQuery.simple))
+                && Optional.ofNullable(this.simpleWeight).equals(Optional.ofNullable(rhsQuery.simpleWeight))
                 && Optional.ofNullable(this.id).equals(Optional.ofNullable(rhsQuery.id))
                 && Optional.ofNullable(this.isFeatured).equals(Optional.ofNullable(rhsQuery.isFeatured))
                 && Optional.ofNullable(this.name).equals(Optional.ofNullable(rhsQuery.name))

--- a/src/main/java/io/citrine/jcc/search/file/query/FileQuery.java
+++ b/src/main/java/io/citrine/jcc/search/file/query/FileQuery.java
@@ -439,7 +439,9 @@ public class FileQuery implements HasLogic, HasWeight {
         }
         final FileQuery rhsQuery = (FileQuery) rhs;
         return Optional.ofNullable(this.logic).equals(Optional.ofNullable(rhsQuery.logic))
+                && Optional.ofNullable(this.weight).equals(Optional.ofNullable(rhsQuery.weight))
                 && Optional.ofNullable(this.simple).equals(Optional.ofNullable(rhsQuery.simple))
+                && Optional.ofNullable(this.simpleWeight).equals(Optional.ofNullable(rhsQuery.simpleWeight))
                 && Optional.ofNullable(this.id).equals(Optional.ofNullable(rhsQuery.id))
                 && Optional.ofNullable(this.name).equals(Optional.ofNullable(rhsQuery.name))
                 && Optional.ofNullable(this.content).equals(Optional.ofNullable(rhsQuery.content))

--- a/src/main/java/io/citrine/jcc/search/file/query/FileQuery.java
+++ b/src/main/java/io/citrine/jcc/search/file/query/FileQuery.java
@@ -6,6 +6,7 @@ import io.citrine.jcc.search.core.query.HasSimple;
 import io.citrine.jcc.search.core.query.HasWeight;
 import io.citrine.jcc.search.core.query.Logic;
 import io.citrine.jcc.util.ListUtil;
+import io.citrine.jcc.util.MapUtil;
 
 import java.util.List;
 import java.util.Map;
@@ -54,6 +55,18 @@ public class FileQuery implements HasLogic, HasWeight, HasSimple {
     @Override
     public FileQuery setSimpleWeight(final Map<String, Double> simpleWeight) {
         this.simpleWeight = simpleWeight;
+        return this;
+    }
+
+    @Override
+    public FileQuery addSimpleWeight(final Map<String, Double> simpleWeight) {
+        this.simpleWeight = MapUtil.add(simpleWeight, this.simpleWeight);
+        return this;
+    }
+
+    @Override
+    public FileQuery addSimpleWeight(final String field, final Double weight) {
+        this.simpleWeight = MapUtil.add(field, weight, this.simpleWeight);
         return this;
     }
 

--- a/src/main/java/io/citrine/jcc/search/file/query/FileQuery.java
+++ b/src/main/java/io/citrine/jcc/search/file/query/FileQuery.java
@@ -7,6 +7,7 @@ import io.citrine.jcc.search.core.query.Logic;
 import io.citrine.jcc.util.ListUtil;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -56,6 +57,26 @@ public class FileQuery implements HasLogic, HasWeight {
      */
     public String getSimple() {
         return this.simple;
+    }
+
+    /**
+     * Set the map of relative field paths to their weights for simple queries.
+     *
+     * @param simpleWeight Map of field paths to weights.
+     * @return This object.
+     */
+    public FileQuery setSimpleWeight(final Map<String, Double> simpleWeight) {
+        this.simpleWeight = simpleWeight;
+        return this;
+    }
+
+    /**
+     * Get the map of relative field paths to their weights for simple queries.
+     *
+     * @return Map of field paths to weights.
+     */
+    public Map<String, Double> getSimpleWeight() {
+        return this.simpleWeight;
     }
 
     /**
@@ -434,6 +455,9 @@ public class FileQuery implements HasLogic, HasWeight {
 
     /** String with the simple search to run against all fields. */
     private String simple;
+
+    /** Map of field names to weights for the simple search string. */
+    private Map<String, Double> simpleWeight;
 
     /** List of filters against the file ID. */
     private List<Filter> id;

--- a/src/main/java/io/citrine/jcc/search/file/query/FileQuery.java
+++ b/src/main/java/io/citrine/jcc/search/file/query/FileQuery.java
@@ -2,6 +2,7 @@ package io.citrine.jcc.search.file.query;
 
 import io.citrine.jcc.search.core.query.Filter;
 import io.citrine.jcc.search.core.query.HasLogic;
+import io.citrine.jcc.search.core.query.HasWeight;
 import io.citrine.jcc.search.core.query.Logic;
 import io.citrine.jcc.util.ListUtil;
 
@@ -13,7 +14,7 @@ import java.util.Optional;
  *
  * @author Kyle Michel
  */
-public class FileQuery implements HasLogic {
+public class FileQuery implements HasLogic, HasWeight {
 
     @Override
     public FileQuery setLogic(final Logic logic) {
@@ -24,6 +25,17 @@ public class FileQuery implements HasLogic {
     @Override
     public Logic getLogic() {
         return this.logic;
+    }
+
+    @Override
+    public FileQuery setWeight(final Double weight) {
+        this.weight = weight;
+        return this;
+    }
+
+    @Override
+    public Double getWeight() {
+        return this.weight;
     }
 
     /**
@@ -416,6 +428,9 @@ public class FileQuery implements HasLogic {
 
     /** Logic for the query. */
     private Logic logic;
+
+    /** Weight of the query. */
+    private Double weight;
 
     /** String with the simple search to run against all fields. */
     private String simple;

--- a/src/main/java/io/citrine/jcc/search/file/query/FileQuery.java
+++ b/src/main/java/io/citrine/jcc/search/file/query/FileQuery.java
@@ -2,6 +2,7 @@ package io.citrine.jcc.search.file.query;
 
 import io.citrine.jcc.search.core.query.Filter;
 import io.citrine.jcc.search.core.query.HasLogic;
+import io.citrine.jcc.search.core.query.HasSimple;
 import io.citrine.jcc.search.core.query.HasWeight;
 import io.citrine.jcc.search.core.query.Logic;
 import io.citrine.jcc.util.ListUtil;
@@ -15,7 +16,7 @@ import java.util.Optional;
  *
  * @author Kyle Michel
  */
-public class FileQuery implements HasLogic, HasWeight {
+public class FileQuery implements HasLogic, HasWeight, HasSimple {
 
     @Override
     public FileQuery setLogic(final Logic logic) {
@@ -39,42 +40,24 @@ public class FileQuery implements HasLogic, HasWeight {
         return this.weight;
     }
 
-    /**
-     * Set the query to run against all fields.
-     *
-     * @param simple String with the query to run against all fields.
-     * @return This object.
-     */
+    @Override
     public FileQuery setSimple(final String simple) {
         this.simple = simple;
         return this;
     }
 
-    /**
-     * Get the query to run against all fields.
-     *
-     * @return String with the query to run against all fields.
-     */
+    @Override
     public String getSimple() {
         return this.simple;
     }
 
-    /**
-     * Set the map of relative field paths to their weights for simple queries.
-     *
-     * @param simpleWeight Map of field paths to weights.
-     * @return This object.
-     */
+    @Override
     public FileQuery setSimpleWeight(final Map<String, Double> simpleWeight) {
         this.simpleWeight = simpleWeight;
         return this;
     }
 
-    /**
-     * Get the map of relative field paths to their weights for simple queries.
-     *
-     * @return Map of field paths to weights.
-     */
+    @Override
     public Map<String, Double> getSimpleWeight() {
         return this.simpleWeight;
     }

--- a/src/main/java/io/citrine/jcc/search/pif/query/PifSystemQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/PifSystemQuery.java
@@ -32,6 +32,12 @@ public class PifSystemQuery extends BaseObjectQuery {
     }
 
     @Override
+    public PifSystemQuery setWeight(final Double weight) {
+        super.setWeight(weight);
+        return this;
+    }
+
+    @Override
     public PifSystemQuery setSimple(final String simple) {
         super.setSimple(simple);
         return this;

--- a/src/main/java/io/citrine/jcc/search/pif/query/PifSystemQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/PifSystemQuery.java
@@ -51,6 +51,18 @@ public class PifSystemQuery extends BaseObjectQuery {
     }
 
     @Override
+    public PifSystemQuery addSimpleWeight(final Map<String, Double> simpleWeight) {
+        super.addSimpleWeight(simpleWeight);
+        return this;
+    }
+
+    @Override
+    public PifSystemQuery addSimpleWeight(final String field, final Double weight) {
+        super.addSimpleWeight(field, weight);
+        return this;
+    }
+
+    @Override
     public PifSystemQuery setExtractAs(final String extractAs) {
         super.setExtractAs(extractAs);
         return this;

--- a/src/main/java/io/citrine/jcc/search/pif/query/PifSystemQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/PifSystemQuery.java
@@ -16,6 +16,7 @@ import io.citrine.jcc.search.pif.query.core.SourceQuery;
 import io.citrine.jcc.util.ListUtil;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -40,6 +41,12 @@ public class PifSystemQuery extends BaseObjectQuery {
     @Override
     public PifSystemQuery setSimple(final String simple) {
         super.setSimple(simple);
+        return this;
+    }
+
+    @Override
+    public PifSystemQuery setSimpleWeight(final Map<String, Double> simpleWeight) {
+        super.setSimpleWeight(simpleWeight);
         return this;
     }
 

--- a/src/main/java/io/citrine/jcc/search/pif/query/chemical/ChemicalFieldQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/chemical/ChemicalFieldQuery.java
@@ -8,6 +8,7 @@ import io.citrine.jcc.search.pif.query.core.FieldQuery;
 import io.citrine.jcc.util.ListUtil;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -38,6 +39,12 @@ public class ChemicalFieldQuery extends BaseFieldQuery implements HasChemicalFil
     @Override
     public ChemicalFieldQuery setSimple(final String simple) {
         super.setSimple(simple);
+        return this;
+    }
+
+    @Override
+    public ChemicalFieldQuery setSimpleWeight(final Map<String, Double> simpleWeight) {
+        super.setSimpleWeight(simpleWeight);
         return this;
     }
 

--- a/src/main/java/io/citrine/jcc/search/pif/query/chemical/ChemicalFieldQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/chemical/ChemicalFieldQuery.java
@@ -6,6 +6,7 @@ import io.citrine.jcc.search.core.query.SortOrder;
 import io.citrine.jcc.search.pif.query.core.BaseFieldQuery;
 import io.citrine.jcc.search.pif.query.core.FieldQuery;
 import io.citrine.jcc.util.ListUtil;
+import io.citrine.jcc.util.MapUtil;
 
 import java.util.List;
 import java.util.Map;
@@ -45,6 +46,18 @@ public class ChemicalFieldQuery extends BaseFieldQuery implements HasChemicalFil
     @Override
     public ChemicalFieldQuery setSimpleWeight(final Map<String, Double> simpleWeight) {
         super.setSimpleWeight(simpleWeight);
+        return this;
+    }
+
+    @Override
+    public ChemicalFieldQuery addSimpleWeight(final Map<String, Double> simpleWeight) {
+        super.addSimpleWeight(simpleWeight);
+        return this;
+    }
+
+    @Override
+    public ChemicalFieldQuery addSimpleWeight(final String field, final Double weight) {
+        super.addSimpleWeight(field, weight);
         return this;
     }
 

--- a/src/main/java/io/citrine/jcc/search/pif/query/chemical/ChemicalFieldQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/chemical/ChemicalFieldQuery.java
@@ -24,6 +24,12 @@ public class ChemicalFieldQuery extends BaseFieldQuery implements HasChemicalFil
     }
 
     @Override
+    public ChemicalFieldQuery setWeight(final Double weight) {
+        super.setWeight(weight);
+        return this;
+    }
+
+    @Override
     public ChemicalFieldQuery setSort(final SortOrder sort) {
         super.setSort(sort);
         return this;

--- a/src/main/java/io/citrine/jcc/search/pif/query/chemical/ChemicalFilter.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/chemical/ChemicalFilter.java
@@ -186,6 +186,7 @@ public class ChemicalFilter implements HasLogic, HasWeight, HasChemicalFilter {
         }
         final ChemicalFilter rhsFilter = (ChemicalFilter) rhs;
         return Optional.ofNullable(this.logic).equals(Optional.ofNullable(rhsFilter.logic))
+                && Optional.ofNullable(this.weight).equals(Optional.ofNullable(rhsFilter.weight))
                 && Optional.ofNullable(this.exists).equals(Optional.ofNullable(rhsFilter.exists))
                 && Optional.ofNullable(this.equal).equals(Optional.ofNullable(rhsFilter.equal))
                 && Optional.ofNullable(this.element).equals(Optional.ofNullable(rhsFilter.element))

--- a/src/main/java/io/citrine/jcc/search/pif/query/chemical/ChemicalFilter.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/chemical/ChemicalFilter.java
@@ -1,6 +1,7 @@
 package io.citrine.jcc.search.pif.query.chemical;
 
 import io.citrine.jcc.search.core.query.HasLogic;
+import io.citrine.jcc.search.core.query.HasWeight;
 import io.citrine.jcc.search.core.query.Logic;
 import io.citrine.jcc.util.ListUtil;
 
@@ -12,7 +13,7 @@ import java.util.Optional;
  * 
  * @author Kyle Michel
  */
-public class ChemicalFilter implements HasLogic, HasChemicalFilter {
+public class ChemicalFilter implements HasLogic, HasWeight, HasChemicalFilter {
 
     @Override
     public ChemicalFilter setLogic(final Logic logic) {
@@ -23,6 +24,17 @@ public class ChemicalFilter implements HasLogic, HasChemicalFilter {
     @Override
     public Logic getLogic() {
         return this.logic;
+    }
+
+    @Override
+    public ChemicalFilter setWeight(final Double weight) {
+        this.weight = weight;
+        return this;
+    }
+
+    @Override
+    public Double getWeight() {
+        return this.weight;
     }
 
     @Override
@@ -184,6 +196,9 @@ public class ChemicalFilter implements HasLogic, HasChemicalFilter {
 
     /** Logic for applying the filters. */
     private Logic logic;
+
+    /** Weight of the query. */
+    private Double weight;
 
     /** Just check for existence. */
     private Boolean exists;

--- a/src/main/java/io/citrine/jcc/search/pif/query/chemical/CompositionQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/chemical/CompositionQuery.java
@@ -22,6 +22,12 @@ public class CompositionQuery extends BaseObjectQuery {
     }
 
     @Override
+    public CompositionQuery setWeight(final Double weight) {
+        super.setWeight(weight);
+        return this;
+    }
+
+    @Override
     public CompositionQuery setSimple(final String simple) {
         super.setSimple(simple);
         return this;

--- a/src/main/java/io/citrine/jcc/search/pif/query/chemical/CompositionQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/chemical/CompositionQuery.java
@@ -6,6 +6,7 @@ import io.citrine.jcc.search.pif.query.core.FieldQuery;
 import io.citrine.jcc.util.ListUtil;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -30,6 +31,12 @@ public class CompositionQuery extends BaseObjectQuery {
     @Override
     public CompositionQuery setSimple(final String simple) {
         super.setSimple(simple);
+        return this;
+    }
+
+    @Override
+    public CompositionQuery setSimpleWeight(final Map<String, Double> simpleWeight) {
+        super.setSimpleWeight(simpleWeight);
         return this;
     }
 

--- a/src/main/java/io/citrine/jcc/search/pif/query/chemical/CompositionQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/chemical/CompositionQuery.java
@@ -41,6 +41,18 @@ public class CompositionQuery extends BaseObjectQuery {
     }
 
     @Override
+    public CompositionQuery addSimpleWeight(final Map<String, Double> simpleWeight) {
+        super.addSimpleWeight(simpleWeight);
+        return this;
+    }
+
+    @Override
+    public CompositionQuery addSimpleWeight(final String field, final Double weight) {
+        super.addSimpleWeight(field, weight);
+        return this;
+    }
+
+    @Override
     public CompositionQuery setExtractAs(final String extractAs) {
         super.setExtractAs(extractAs);
         return this;

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/BaseFieldQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/BaseFieldQuery.java
@@ -1,6 +1,7 @@
 package io.citrine.jcc.search.pif.query.core;
 
 import io.citrine.jcc.search.core.query.HasLogic;
+import io.citrine.jcc.search.core.query.HasSimple;
 import io.citrine.jcc.search.core.query.HasWeight;
 import io.citrine.jcc.search.core.query.Logic;
 import io.citrine.jcc.search.core.query.SortOrder;
@@ -16,7 +17,7 @@ import java.util.Optional;
  *
  * @author Kyle Michel
  */
-public abstract class BaseFieldQuery implements HasLogic, HasWeight {
+public abstract class BaseFieldQuery implements HasLogic, HasWeight, HasSimple {
 
     @Override
     public BaseFieldQuery setLogic(final Logic logic) {
@@ -40,6 +41,28 @@ public abstract class BaseFieldQuery implements HasLogic, HasWeight {
         return this.weight;
     }
 
+    @Override
+    public BaseFieldQuery setSimple(final String simple) {
+        this.simple = simple;
+        return this;
+    }
+
+    @Override
+    public String getSimple() {
+        return this.simple;
+    }
+
+    @Override
+    public BaseFieldQuery setSimpleWeight(final Map<String, Double> simpleWeight) {
+        this.simpleWeight = simpleWeight;
+        return this;
+    }
+
+    @Override
+    public Map<String, Double> getSimpleWeight() {
+        return this.simpleWeight;
+    }
+
     /**
      * Set the sort order to use.
      *
@@ -58,46 +81,6 @@ public abstract class BaseFieldQuery implements HasLogic, HasWeight {
      */
     public SortOrder getSort() {
         return this.sort;
-    }
-
-    /**
-     * Set the query to run against all fields.
-     *
-     * @param simple String with the query to run against all fields.
-     * @return This object.
-     */
-    public BaseFieldQuery setSimple(final String simple) {
-        this.simple = simple;
-        return this;
-    }
-
-    /**
-     * Get the query to run against all fields.
-     *
-     * @return String with the query to run against all fields.
-     */
-    public String getSimple() {
-        return this.simple;
-    }
-
-    /**
-     * Set the map of relative field paths to their weights for simple queries.
-     *
-     * @param simpleWeight Map of field paths to weights.
-     * @return This object.
-     */
-    public BaseFieldQuery setSimpleWeight(final Map<String, Double> simpleWeight) {
-        this.simpleWeight = simpleWeight;
-        return this;
-    }
-
-    /**
-     * Get the map of relative field paths to their weights for simple queries.
-     *
-     * @return Map of field paths to weights.
-     */
-    public Map<String, Double> getSimpleWeight() {
-        return this.simpleWeight;
     }
 
     /**

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/BaseFieldQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/BaseFieldQuery.java
@@ -1,6 +1,7 @@
 package io.citrine.jcc.search.pif.query.core;
 
 import io.citrine.jcc.search.core.query.HasLogic;
+import io.citrine.jcc.search.core.query.HasWeight;
 import io.citrine.jcc.search.core.query.Logic;
 import io.citrine.jcc.search.core.query.SortOrder;
 import io.citrine.jcc.util.ListUtil;
@@ -14,7 +15,7 @@ import java.util.Optional;
  *
  * @author Kyle Michel
  */
-public abstract class BaseFieldQuery implements HasLogic {
+public abstract class BaseFieldQuery implements HasLogic, HasWeight {
 
     @Override
     public BaseFieldQuery setLogic(final Logic logic) {
@@ -25,6 +26,17 @@ public abstract class BaseFieldQuery implements HasLogic {
     @Override
     public Logic getLogic() {
         return this.logic;
+    }
+
+    @Override
+    public BaseFieldQuery setWeight(final Double weight) {
+        this.weight = weight;
+        return this;
+    }
+
+    @Override
+    public Double getWeight() {
+        return this.weight;
     }
 
     /**
@@ -292,6 +304,9 @@ public abstract class BaseFieldQuery implements HasLogic {
 
     /** Logic that applies to the entire query. */
     private Logic logic;
+
+    /** Weight of the query. */
+    private Double weight;
 
     /** String with the simple search to run against all fields. */
     private String simple;

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/BaseFieldQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/BaseFieldQuery.java
@@ -312,7 +312,9 @@ public abstract class BaseFieldQuery implements HasLogic, HasWeight {
         final BaseFieldQuery rhsQuery = (BaseFieldQuery) rhs;
         return Optional.ofNullable(this.sort).equals(Optional.ofNullable(rhsQuery.sort))
                 && Optional.ofNullable(this.logic).equals(Optional.ofNullable(rhsQuery.logic))
+                && Optional.ofNullable(this.weight).equals(Optional.ofNullable(rhsQuery.weight))
                 && Optional.ofNullable(this.simple).equals(Optional.ofNullable(rhsQuery.simple))
+                && Optional.ofNullable(this.simpleWeight).equals(Optional.ofNullable(rhsQuery.simpleWeight))
                 && Optional.ofNullable(this.extractAs).equals(Optional.ofNullable(rhsQuery.extractAs))
                 && Optional.ofNullable(this.extractAll).equals(Optional.ofNullable(rhsQuery.extractAll))
                 && Optional.ofNullable(this.extractWhenMissing).equals(Optional.ofNullable(rhsQuery.extractWhenMissing))

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/BaseFieldQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/BaseFieldQuery.java
@@ -7,6 +7,7 @@ import io.citrine.jcc.search.core.query.SortOrder;
 import io.citrine.jcc.util.ListUtil;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 
@@ -77,6 +78,26 @@ public abstract class BaseFieldQuery implements HasLogic, HasWeight {
      */
     public String getSimple() {
         return this.simple;
+    }
+
+    /**
+     * Set the map of relative field paths to their weights for simple queries.
+     *
+     * @param simpleWeight Map of field paths to weights.
+     * @return This object.
+     */
+    public BaseFieldQuery setSimpleWeight(final Map<String, Double> simpleWeight) {
+        this.simpleWeight = simpleWeight;
+        return this;
+    }
+
+    /**
+     * Get the map of relative field paths to their weights for simple queries.
+     *
+     * @return Map of field paths to weights.
+     */
+    public Map<String, Double> getSimpleWeight() {
+        return this.simpleWeight;
     }
 
     /**
@@ -310,6 +331,9 @@ public abstract class BaseFieldQuery implements HasLogic, HasWeight {
 
     /** String with the simple search to run against all fields. */
     private String simple;
+
+    /** Map of field names to weights for the simple search string. */
+    private Map<String, Double> simpleWeight;
 
     /** Alias to save this field under. */
     private String extractAs;

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/BaseFieldQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/BaseFieldQuery.java
@@ -6,6 +6,7 @@ import io.citrine.jcc.search.core.query.HasWeight;
 import io.citrine.jcc.search.core.query.Logic;
 import io.citrine.jcc.search.core.query.SortOrder;
 import io.citrine.jcc.util.ListUtil;
+import io.citrine.jcc.util.MapUtil;
 
 import java.util.List;
 import java.util.Map;
@@ -55,6 +56,18 @@ public abstract class BaseFieldQuery implements HasLogic, HasWeight, HasSimple {
     @Override
     public BaseFieldQuery setSimpleWeight(final Map<String, Double> simpleWeight) {
         this.simpleWeight = simpleWeight;
+        return this;
+    }
+
+    @Override
+    public BaseFieldQuery addSimpleWeight(final Map<String, Double> simpleWeight) {
+        this.simpleWeight = MapUtil.add(simpleWeight, this.simpleWeight);
+        return this;
+    }
+
+    @Override
+    public BaseFieldQuery addSimpleWeight(final String field, final Double weight) {
+        this.simpleWeight = MapUtil.add(field, weight, this.simpleWeight);
         return this;
     }
 

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/BaseObjectQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/BaseObjectQuery.java
@@ -359,7 +359,9 @@ public abstract class BaseObjectQuery implements HasLogic, HasWeight {
         }
         final BaseObjectQuery rhsQuery = (BaseObjectQuery) rhs;
         return Optional.ofNullable(this.logic).equals(Optional.ofNullable(rhsQuery.logic))
+                && Optional.ofNullable(this.weight).equals(Optional.ofNullable(rhsQuery.weight))
                 && Optional.ofNullable(this.simple).equals(Optional.ofNullable(rhsQuery.simple))
+                && Optional.ofNullable(this.simpleWeight).equals(Optional.ofNullable(rhsQuery.simpleWeight))
                 && Optional.ofNullable(this.extractAs).equals(Optional.ofNullable(rhsQuery.extractAs))
                 && Optional.ofNullable(this.extractAll).equals(Optional.ofNullable(rhsQuery.extractAll))
                 && Optional.ofNullable(this.extractWhenMissing).equals(Optional.ofNullable(rhsQuery.extractWhenMissing))

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/BaseObjectQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/BaseObjectQuery.java
@@ -1,6 +1,7 @@
 package io.citrine.jcc.search.pif.query.core;
 
 import io.citrine.jcc.search.core.query.HasLogic;
+import io.citrine.jcc.search.core.query.HasWeight;
 import io.citrine.jcc.search.core.query.Logic;
 import io.citrine.jcc.util.ListUtil;
 
@@ -12,7 +13,7 @@ import java.util.Optional;
  * 
  * @author Kyle Michel
  */
-public abstract class BaseObjectQuery implements HasLogic {
+public abstract class BaseObjectQuery implements HasLogic, HasWeight {
 
     @Override
     public BaseObjectQuery setLogic(final Logic logic) {
@@ -23,6 +24,17 @@ public abstract class BaseObjectQuery implements HasLogic {
     @Override
     public Logic getLogic() {
         return this.logic;
+    }
+
+    @Override
+    public BaseObjectQuery setWeight(final Double weight) {
+        this.weight = weight;
+        return this;
+    }
+
+    @Override
+    public Double getWeight() {
+        return this.weight;
     }
 
     /**
@@ -337,6 +349,9 @@ public abstract class BaseObjectQuery implements HasLogic {
 
     /** Logic that applies to the entire query. */
     private Logic logic;
+
+    /** Weight of the query. */
+    private Double weight;
 
     /** String with the simple search to run against all fields. */
     private String simple;

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/BaseObjectQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/BaseObjectQuery.java
@@ -5,6 +5,7 @@ import io.citrine.jcc.search.core.query.HasSimple;
 import io.citrine.jcc.search.core.query.HasWeight;
 import io.citrine.jcc.search.core.query.Logic;
 import io.citrine.jcc.util.ListUtil;
+import io.citrine.jcc.util.MapUtil;
 
 import java.util.List;
 import java.util.Map;
@@ -53,6 +54,18 @@ public abstract class BaseObjectQuery implements HasLogic, HasWeight, HasSimple 
     @Override
     public BaseObjectQuery setSimpleWeight(final Map<String, Double> simpleWeight) {
         this.simpleWeight = simpleWeight;
+        return this;
+    }
+
+    @Override
+    public BaseObjectQuery addSimpleWeight(final Map<String, Double> simpleWeight) {
+        this.simpleWeight = MapUtil.add(simpleWeight, this.simpleWeight);
+        return this;
+    }
+
+    @Override
+    public BaseObjectQuery addSimpleWeight(final String field, final Double weight) {
+        this.simpleWeight = MapUtil.add(field, weight, this.simpleWeight);
         return this;
     }
 

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/BaseObjectQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/BaseObjectQuery.java
@@ -6,6 +6,7 @@ import io.citrine.jcc.search.core.query.Logic;
 import io.citrine.jcc.util.ListUtil;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -55,6 +56,26 @@ public abstract class BaseObjectQuery implements HasLogic, HasWeight {
      */
     public String getSimple() {
         return this.simple;
+    }
+
+    /**
+     * Set the map of relative field paths to their weights for simple queries.
+     *
+     * @param simpleWeight Map of field paths to weights.
+     * @return This object.
+     */
+    public BaseObjectQuery setSimpleWeight(final Map<String, Double> simpleWeight) {
+        this.simpleWeight = simpleWeight;
+        return this;
+    }
+
+    /**
+     * Get the map of relative field paths to their weights for simple queries.
+     *
+     * @return Map of field paths to weights.
+     */
+    public Map<String, Double> getSimpleWeight() {
+        return this.simpleWeight;
     }
 
     /**
@@ -355,6 +376,9 @@ public abstract class BaseObjectQuery implements HasLogic, HasWeight {
 
     /** String with the simple search to run against all fields. */
     private String simple;
+
+    /** Map of field names to weights for the simple search string. */
+    private Map<String, Double> simpleWeight;
 
     /** Alias to save this field under. */
     private String extractAs;

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/BaseObjectQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/BaseObjectQuery.java
@@ -1,6 +1,7 @@
 package io.citrine.jcc.search.pif.query.core;
 
 import io.citrine.jcc.search.core.query.HasLogic;
+import io.citrine.jcc.search.core.query.HasSimple;
 import io.citrine.jcc.search.core.query.HasWeight;
 import io.citrine.jcc.search.core.query.Logic;
 import io.citrine.jcc.util.ListUtil;
@@ -14,7 +15,7 @@ import java.util.Optional;
  * 
  * @author Kyle Michel
  */
-public abstract class BaseObjectQuery implements HasLogic, HasWeight {
+public abstract class BaseObjectQuery implements HasLogic, HasWeight, HasSimple {
 
     @Override
     public BaseObjectQuery setLogic(final Logic logic) {
@@ -38,42 +39,24 @@ public abstract class BaseObjectQuery implements HasLogic, HasWeight {
         return this.weight;
     }
 
-    /**
-     * Set the query to run against all fields.
-     *
-     * @param simple String with the query to run against all fields.
-     * @return This object.
-     */
+    @Override
     public BaseObjectQuery setSimple(final String simple) {
         this.simple = simple;
         return this;
     }
 
-    /**
-     * Get the query to run against all fields.
-     *
-     * @return String with the query to run against all fields.
-     */
+    @Override
     public String getSimple() {
         return this.simple;
     }
 
-    /**
-     * Set the map of relative field paths to their weights for simple queries.
-     *
-     * @param simpleWeight Map of field paths to weights.
-     * @return This object.
-     */
+    @Override
     public BaseObjectQuery setSimpleWeight(final Map<String, Double> simpleWeight) {
         this.simpleWeight = simpleWeight;
         return this;
     }
 
-    /**
-     * Get the map of relative field paths to their weights for simple queries.
-     *
-     * @return Map of field paths to weights.
-     */
+    @Override
     public Map<String, Double> getSimpleWeight() {
         return this.simpleWeight;
     }

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/ClassificationQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/ClassificationQuery.java
@@ -20,6 +20,12 @@ public class ClassificationQuery extends BaseObjectQuery {
     }
 
     @Override
+    public ClassificationQuery setWeight(final Double weight) {
+        super.setWeight(weight);
+        return this;
+    }
+
+    @Override
     public ClassificationQuery setSimple(final String simple) {
         super.setSimple(simple);
         return this;

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/ClassificationQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/ClassificationQuery.java
@@ -4,6 +4,7 @@ import io.citrine.jcc.search.core.query.Logic;
 import io.citrine.jcc.util.ListUtil;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -28,6 +29,12 @@ public class ClassificationQuery extends BaseObjectQuery {
     @Override
     public ClassificationQuery setSimple(final String simple) {
         super.setSimple(simple);
+        return this;
+    }
+
+    @Override
+    public ClassificationQuery setSimpleWeight(final Map<String, Double> simpleWeight) {
+        super.setSimpleWeight(simpleWeight);
         return this;
     }
 

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/ClassificationQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/ClassificationQuery.java
@@ -39,6 +39,18 @@ public class ClassificationQuery extends BaseObjectQuery {
     }
 
     @Override
+    public ClassificationQuery addSimpleWeight(final Map<String, Double> simpleWeight) {
+        super.addSimpleWeight(simpleWeight);
+        return this;
+    }
+
+    @Override
+    public ClassificationQuery addSimpleWeight(final String field, final Double weight) {
+        super.addSimpleWeight(field, weight);
+        return this;
+    }
+
+    @Override
     public ClassificationQuery setExtractAs(final String extractAs) {
         super.setExtractAs(extractAs);
         return this;

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/DisplayItemQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/DisplayItemQuery.java
@@ -19,6 +19,12 @@ public class DisplayItemQuery extends BaseObjectQuery {
     }
 
     @Override
+    public DisplayItemQuery setWeight(final Double weight) {
+        super.setWeight(weight);
+        return this;
+    }
+
+    @Override
     public DisplayItemQuery setSimple(final String simple) {
         super.setSimple(simple);
         return this;

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/DisplayItemQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/DisplayItemQuery.java
@@ -5,6 +5,7 @@ import io.citrine.jcc.util.ListUtil;
 import io.citrine.jpif.obj.common.DisplayItem;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -27,6 +28,12 @@ public class DisplayItemQuery extends BaseObjectQuery {
     @Override
     public DisplayItemQuery setSimple(final String simple) {
         super.setSimple(simple);
+        return this;
+    }
+
+    @Override
+    public DisplayItemQuery setSimpleWeight(final Map<String, Double> simpleWeight) {
+        super.setSimpleWeight(simpleWeight);
         return this;
     }
 

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/DisplayItemQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/DisplayItemQuery.java
@@ -38,6 +38,18 @@ public class DisplayItemQuery extends BaseObjectQuery {
     }
 
     @Override
+    public DisplayItemQuery addSimpleWeight(final Map<String, Double> simpleWeight) {
+        super.addSimpleWeight(simpleWeight);
+        return this;
+    }
+
+    @Override
+    public DisplayItemQuery addSimpleWeight(final String field, final Double weight) {
+        super.addSimpleWeight(field, weight);
+        return this;
+    }
+
+    @Override
     public DisplayItemQuery setExtractAs(final String extractAs) {
         super.setExtractAs(extractAs);
         return this;

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/FieldQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/FieldQuery.java
@@ -8,6 +8,7 @@ import io.citrine.jcc.search.core.query.SortOrder;
 import io.citrine.jcc.util.ListUtil;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -38,6 +39,12 @@ public class FieldQuery extends BaseFieldQuery implements HasFilter {
     @Override
     public FieldQuery setSimple(final String simple) {
         super.setSimple(simple);
+        return this;
+    }
+
+    @Override
+    public FieldQuery setSimpleWeight(final Map<String, Double> simpleWeight) {
+        super.setSimpleWeight(simpleWeight);
         return this;
     }
 

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/FieldQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/FieldQuery.java
@@ -24,6 +24,12 @@ public class FieldQuery extends BaseFieldQuery implements HasFilter {
     }
 
     @Override
+    public FieldQuery setWeight(final Double weight) {
+        super.setWeight(weight);
+        return this;
+    }
+
+    @Override
     public FieldQuery setSort(final SortOrder sort) {
         super.setSort(sort);
         return this;

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/FieldQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/FieldQuery.java
@@ -49,6 +49,18 @@ public class FieldQuery extends BaseFieldQuery implements HasFilter {
     }
 
     @Override
+    public FieldQuery addSimpleWeight(final Map<String, Double> simpleWeight) {
+        super.addSimpleWeight(simpleWeight);
+        return this;
+    }
+
+    @Override
+    public FieldQuery addSimpleWeight(final String field, final Double weight) {
+        super.addSimpleWeight(field, weight);
+        return this;
+    }
+
+    @Override
     public FieldQuery setExtractAs(final String extractAs) {
         super.setExtractAs(extractAs);
         return this;

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/FileReferenceQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/FileReferenceQuery.java
@@ -20,6 +20,12 @@ public class FileReferenceQuery extends BaseObjectQuery {
     }
 
     @Override
+    public FileReferenceQuery setWeight(final Double weight) {
+        super.setWeight(weight);
+        return this;
+    }
+
+    @Override
     public FileReferenceQuery setSimple(final String simple) {
         super.setSimple(simple);
         return this;

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/FileReferenceQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/FileReferenceQuery.java
@@ -39,6 +39,18 @@ public class FileReferenceQuery extends BaseObjectQuery {
     }
 
     @Override
+    public FileReferenceQuery addSimpleWeight(final Map<String, Double> simpleWeight) {
+        super.addSimpleWeight(simpleWeight);
+        return this;
+    }
+
+    @Override
+    public FileReferenceQuery addSimpleWeight(final String field, final Double weight) {
+        super.addSimpleWeight(field, weight);
+        return this;
+    }
+
+    @Override
     public FileReferenceQuery setExtractAs(final String extractAs) {
         super.setExtractAs(extractAs);
         return this;

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/FileReferenceQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/FileReferenceQuery.java
@@ -4,6 +4,7 @@ import io.citrine.jcc.search.core.query.Logic;
 import io.citrine.jcc.util.ListUtil;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -28,6 +29,12 @@ public class FileReferenceQuery extends BaseObjectQuery {
     @Override
     public FileReferenceQuery setSimple(final String simple) {
         super.setSimple(simple);
+        return this;
+    }
+
+    @Override
+    public FileReferenceQuery setSimpleWeight(final Map<String, Double> simpleWeight) {
+        super.setSimpleWeight(simpleWeight);
         return this;
     }
 

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/IdQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/IdQuery.java
@@ -20,6 +20,12 @@ public class IdQuery extends BaseObjectQuery {
     }
 
     @Override
+    public IdQuery setWeight(final Double weight) {
+        super.setWeight(weight);
+        return this;
+    }
+
+    @Override
     public IdQuery setSimple(final String simple) {
         super.setSimple(simple);
         return this;

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/IdQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/IdQuery.java
@@ -39,6 +39,18 @@ public class IdQuery extends BaseObjectQuery {
     }
 
     @Override
+    public IdQuery addSimpleWeight(final Map<String, Double> simpleWeight) {
+        super.addSimpleWeight(simpleWeight);
+        return this;
+    }
+
+    @Override
+    public IdQuery addSimpleWeight(final String field, final Double weight) {
+        super.addSimpleWeight(field, weight);
+        return this;
+    }
+
+    @Override
     public IdQuery setExtractAs(final String extractAs) {
         super.setExtractAs(extractAs);
         return this;

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/IdQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/IdQuery.java
@@ -4,6 +4,7 @@ import io.citrine.jcc.search.core.query.Logic;
 import io.citrine.jcc.util.ListUtil;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -28,6 +29,12 @@ public class IdQuery extends BaseObjectQuery {
     @Override
     public IdQuery setSimple(final String simple) {
         super.setSimple(simple);
+        return this;
+    }
+
+    @Override
+    public IdQuery setSimpleWeight(final Map<String, Double> simpleWeight) {
+        super.setSimpleWeight(simpleWeight);
         return this;
     }
 

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/NameQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/NameQuery.java
@@ -20,6 +20,12 @@ public class NameQuery extends BaseObjectQuery {
     }
 
     @Override
+    public NameQuery setWeight(final Double weight) {
+        super.setWeight(weight);
+        return this;
+    }
+
+    @Override
     public NameQuery setSimple(final String simple) {
         super.setSimple(simple);
         return this;

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/NameQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/NameQuery.java
@@ -39,6 +39,18 @@ public class NameQuery extends BaseObjectQuery {
     }
 
     @Override
+    public NameQuery addSimpleWeight(final Map<String, Double> simpleWeight) {
+        super.addSimpleWeight(simpleWeight);
+        return this;
+    }
+
+    @Override
+    public NameQuery addSimpleWeight(final String field, final Double weight) {
+        super.addSimpleWeight(field, weight);
+        return this;
+    }
+
+    @Override
     public NameQuery setExtractAs(final String extractAs) {
         super.setExtractAs(extractAs);
         return this;

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/NameQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/NameQuery.java
@@ -4,6 +4,7 @@ import io.citrine.jcc.search.core.query.Logic;
 import io.citrine.jcc.util.ListUtil;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -28,6 +29,12 @@ public class NameQuery extends BaseObjectQuery {
     @Override
     public NameQuery setSimple(final String simple) {
         super.setSimple(simple);
+        return this;
+    }
+
+    @Override
+    public NameQuery setSimpleWeight(final Map<String, Double> simpleWeight) {
+        super.setSimpleWeight(simpleWeight);
         return this;
     }
 

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/PagesQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/PagesQuery.java
@@ -20,6 +20,12 @@ public class PagesQuery extends BaseObjectQuery {
     }
 
     @Override
+    public PagesQuery setWeight(final Double weight) {
+        super.setWeight(weight);
+        return this;
+    }
+
+    @Override
     public PagesQuery setSimple(final String simple) {
         super.setSimple(simple);
         return this;

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/PagesQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/PagesQuery.java
@@ -4,6 +4,7 @@ import io.citrine.jcc.search.core.query.Logic;
 import io.citrine.jcc.util.ListUtil;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -28,6 +29,12 @@ public class PagesQuery extends BaseObjectQuery {
     @Override
     public PagesQuery setSimple(final String simple) {
         super.setSimple(simple);
+        return this;
+    }
+
+    @Override
+    public PagesQuery setSimpleWeight(final Map<String, Double> simpleWeight) {
+        super.setSimpleWeight(simpleWeight);
         return this;
     }
 

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/PagesQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/PagesQuery.java
@@ -39,6 +39,18 @@ public class PagesQuery extends BaseObjectQuery {
     }
 
     @Override
+    public PagesQuery addSimpleWeight(final Map<String, Double> simpleWeight) {
+        super.addSimpleWeight(simpleWeight);
+        return this;
+    }
+
+    @Override
+    public PagesQuery addSimpleWeight(final String field, final Double weight) {
+        super.addSimpleWeight(field, weight);
+        return this;
+    }
+
+    @Override
     public PagesQuery setExtractAs(final String extractAs) {
         super.setExtractAs(extractAs);
         return this;

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/ProcessStepQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/ProcessStepQuery.java
@@ -20,6 +20,12 @@ public class ProcessStepQuery extends BaseObjectQuery {
     }
 
     @Override
+    public ProcessStepQuery setWeight(final Double weight) {
+        super.setWeight(weight);
+        return this;
+    }
+
+    @Override
     public ProcessStepQuery setSimple(final String simple) {
         super.setSimple(simple);
         return this;

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/ProcessStepQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/ProcessStepQuery.java
@@ -4,6 +4,7 @@ import io.citrine.jcc.search.core.query.Logic;
 import io.citrine.jcc.util.ListUtil;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -28,6 +29,12 @@ public class ProcessStepQuery extends BaseObjectQuery {
     @Override
     public ProcessStepQuery setSimple(final String simple) {
         super.setSimple(simple);
+        return this;
+    }
+
+    @Override
+    public ProcessStepQuery setSimpleWeight(final Map<String, Double> simpleWeight) {
+        super.setSimpleWeight(simpleWeight);
         return this;
     }
 

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/ProcessStepQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/ProcessStepQuery.java
@@ -39,6 +39,18 @@ public class ProcessStepQuery extends BaseObjectQuery {
     }
 
     @Override
+    public ProcessStepQuery addSimpleWeight(final Map<String, Double> simpleWeight) {
+        super.addSimpleWeight(simpleWeight);
+        return this;
+    }
+
+    @Override
+    public ProcessStepQuery addSimpleWeight(final String field, final Double weight) {
+        super.addSimpleWeight(field, weight);
+        return this;
+    }
+
+    @Override
     public ProcessStepQuery setExtractAs(final String extractAs) {
         super.setExtractAs(extractAs);
         return this;

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/PropertyQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/PropertyQuery.java
@@ -41,6 +41,18 @@ public class PropertyQuery extends ValueQuery {
     }
 
     @Override
+    public PropertyQuery addSimpleWeight(final Map<String, Double> simpleWeight) {
+        super.addSimpleWeight(simpleWeight);
+        return this;
+    }
+
+    @Override
+    public PropertyQuery addSimpleWeight(final String field, final Double weight) {
+        super.addSimpleWeight(field, weight);
+        return this;
+    }
+
+    @Override
     public PropertyQuery setExtractAs(final String extractAs) {
         super.setExtractAs(extractAs);
         return this;

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/PropertyQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/PropertyQuery.java
@@ -22,6 +22,12 @@ public class PropertyQuery extends ValueQuery {
     }
 
     @Override
+    public PropertyQuery setWeight(final Double weight) {
+        super.setWeight(weight);
+        return this;
+    }
+
+    @Override
     public PropertyQuery setSimple(final String simple) {
         super.setSimple(simple);
         return this;

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/PropertyQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/PropertyQuery.java
@@ -5,6 +5,7 @@ import io.citrine.jcc.search.core.query.Logic;
 import io.citrine.jcc.util.ListUtil;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -30,6 +31,12 @@ public class PropertyQuery extends ValueQuery {
     @Override
     public PropertyQuery setSimple(final String simple) {
         super.setSimple(simple);
+        return this;
+    }
+
+    @Override
+    public PropertyQuery setSimpleWeight(final Map<String, Double> simpleWeight) {
+        super.setSimpleWeight(simpleWeight);
         return this;
     }
 

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/QuantityQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/QuantityQuery.java
@@ -39,6 +39,18 @@ public class QuantityQuery extends BaseObjectQuery {
     }
 
     @Override
+    public QuantityQuery addSimpleWeight(final Map<String, Double> simpleWeight) {
+        super.addSimpleWeight(simpleWeight);
+        return this;
+    }
+
+    @Override
+    public QuantityQuery addSimpleWeight(final String field, final Double weight) {
+        super.addSimpleWeight(field, weight);
+        return this;
+    }
+
+    @Override
     public QuantityQuery setExtractAs(final String extractAs) {
         super.setExtractAs(extractAs);
         return this;

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/QuantityQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/QuantityQuery.java
@@ -20,6 +20,12 @@ public class QuantityQuery extends BaseObjectQuery {
     }
 
     @Override
+    public QuantityQuery setWeight(final Double weight) {
+        super.setWeight(weight);
+        return this;
+    }
+
+    @Override
     public QuantityQuery setSimple(final String simple) {
         super.setSimple(simple);
         return this;

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/QuantityQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/QuantityQuery.java
@@ -4,6 +4,7 @@ import io.citrine.jcc.search.core.query.Logic;
 import io.citrine.jcc.util.ListUtil;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -28,6 +29,12 @@ public class QuantityQuery extends BaseObjectQuery {
     @Override
     public QuantityQuery setSimple(final String simple) {
         super.setSimple(simple);
+        return this;
+    }
+
+    @Override
+    public QuantityQuery setSimpleWeight(final Map<String, Double> simpleWeight) {
+        super.setSimpleWeight(simpleWeight);
         return this;
     }
 

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/ReferenceQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/ReferenceQuery.java
@@ -20,6 +20,12 @@ public class ReferenceQuery extends BaseObjectQuery {
     }
 
     @Override
+    public ReferenceQuery setWeight(final Double weight) {
+        super.setWeight(weight);
+        return this;
+    }
+
+    @Override
     public ReferenceQuery setSimple(final String simple) {
         super.setSimple(simple);
         return this;

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/ReferenceQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/ReferenceQuery.java
@@ -39,6 +39,18 @@ public class ReferenceQuery extends BaseObjectQuery {
     }
 
     @Override
+    public ReferenceQuery addSimpleWeight(final Map<String, Double> simpleWeight) {
+        super.addSimpleWeight(simpleWeight);
+        return this;
+    }
+
+    @Override
+    public ReferenceQuery addSimpleWeight(final String field, final Double weight) {
+        super.addSimpleWeight(field, weight);
+        return this;
+    }
+
+    @Override
     public ReferenceQuery setExtractAs(final String extractAs) {
         super.setExtractAs(extractAs);
         return this;

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/ReferenceQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/ReferenceQuery.java
@@ -4,6 +4,7 @@ import io.citrine.jcc.search.core.query.Logic;
 import io.citrine.jcc.util.ListUtil;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -28,6 +29,12 @@ public class ReferenceQuery extends BaseObjectQuery {
     @Override
     public ReferenceQuery setSimple(final String simple) {
         super.setSimple(simple);
+        return this;
+    }
+
+    @Override
+    public ReferenceQuery setSimpleWeight(final Map<String, Double> simpleWeight) {
+        super.setSimpleWeight(simpleWeight);
         return this;
     }
 

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/SourceQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/SourceQuery.java
@@ -39,6 +39,18 @@ public class SourceQuery extends BaseObjectQuery {
     }
 
     @Override
+    public SourceQuery addSimpleWeight(final Map<String, Double> simpleWeight) {
+        super.addSimpleWeight(simpleWeight);
+        return this;
+    }
+
+    @Override
+    public SourceQuery addSimpleWeight(final String field, final Double weight) {
+        super.addSimpleWeight(field, weight);
+        return this;
+    }
+
+    @Override
     public SourceQuery setExtractAs(final String extractAs) {
         super.setExtractAs(extractAs);
         return this;

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/SourceQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/SourceQuery.java
@@ -4,6 +4,7 @@ import io.citrine.jcc.search.core.query.Logic;
 import io.citrine.jcc.util.ListUtil;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -28,6 +29,12 @@ public class SourceQuery extends BaseObjectQuery {
     @Override
     public SourceQuery setSimple(final String simple) {
         super.setSimple(simple);
+        return this;
+    }
+
+    @Override
+    public SourceQuery setSimpleWeight(final Map<String, Double> simpleWeight) {
+        super.setSimpleWeight(simpleWeight);
         return this;
     }
 

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/SourceQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/SourceQuery.java
@@ -20,6 +20,12 @@ public class SourceQuery extends BaseObjectQuery {
     }
 
     @Override
+    public SourceQuery setWeight(final Double weight) {
+        super.setWeight(weight);
+        return this;
+    }
+
+    @Override
     public SourceQuery setSimple(final String simple) {
         super.setSimple(simple);
         return this;

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/ValueQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/ValueQuery.java
@@ -4,6 +4,7 @@ import io.citrine.jcc.search.core.query.Logic;
 import io.citrine.jcc.util.ListUtil;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -28,6 +29,12 @@ public class ValueQuery extends BaseObjectQuery {
     @Override
     public ValueQuery setSimple(final String simple) {
         super.setSimple(simple);
+        return this;
+    }
+
+    @Override
+    public ValueQuery setSimpleWeight(final Map<String, Double> simpleWeight) {
+        super.setSimpleWeight(simpleWeight);
         return this;
     }
 

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/ValueQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/ValueQuery.java
@@ -39,6 +39,18 @@ public class ValueQuery extends BaseObjectQuery {
     }
 
     @Override
+    public ValueQuery addSimpleWeight(final Map<String, Double> simpleWeight) {
+        super.addSimpleWeight(simpleWeight);
+        return this;
+    }
+
+    @Override
+    public ValueQuery addSimpleWeight(final String field, final Double weight) {
+        super.addSimpleWeight(field, weight);
+        return this;
+    }
+
+    @Override
     public ValueQuery setExtractAs(final String extractAs) {
         super.setExtractAs(extractAs);
         return this;

--- a/src/main/java/io/citrine/jcc/search/pif/query/core/ValueQuery.java
+++ b/src/main/java/io/citrine/jcc/search/pif/query/core/ValueQuery.java
@@ -20,6 +20,12 @@ public class ValueQuery extends BaseObjectQuery {
     }
 
     @Override
+    public ValueQuery setWeight(final Double weight) {
+        super.setWeight(weight);
+        return this;
+    }
+
+    @Override
     public ValueQuery setSimple(final String simple) {
         super.setSimple(simple);
         return this;

--- a/src/main/java/io/citrine/jcc/util/MapUtil.java
+++ b/src/main/java/io/citrine/jcc/util/MapUtil.java
@@ -1,0 +1,58 @@
+package io.citrine.jcc.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Utility methods for working with maps.
+ *
+ * @author Kyle Michel
+ */
+public class MapUtil {
+
+    /**
+     * If the input key is non-null then add it to the map, otherwise do nothing. If the map is null and the key is
+     * being added, then create a new map.
+     *
+     * @param key Key of the value to add.
+     * @param value Value to add.
+     * @param map Map to add to.
+     * @param <T> Type of the key.
+     * @param <U> Type of the value.
+     * @return The input map if it was not null. Otherwise a new map with the input value.
+     */
+    public static <T, U> Map<T, U> add(final T key, final U value, Map<T, U> map) {
+        if (key == null) {
+            return map;
+        }
+        if (map == null) {
+            map = new HashMap<>();
+        }
+        map.put(key, value);
+        return map;
+    }
+
+    /**
+     * If the input map is non-null then add all entries to the output map, otherwise do nothing. If the output map
+     * is null and values are being added, then create a new map.
+     *
+     * @param values Map of values to add.
+     * @param map Map to add to.
+     * @param <T> Type of the key.
+     * @param <U> Type of the value.
+     * @return The input map if it was not null. Otherwise a new map with the input value.
+     */
+    public static <T, U> Map<T, U> add(final Map<T, U> values, Map<T, U> map) {
+        if (values == null) {
+            return map;
+        }
+        if (map == null) {
+            map = new HashMap<>();
+        }
+        map.putAll(values);
+        return map;
+    }
+
+    // Make sure that objects of this class cannot be instantiated
+    private MapUtil() {}
+}


### PR DESCRIPTION
This PR repeats 2 main changes a bunch of times:

1. Add a `weight` field to all query objects. These can be used to bias scores for specific query elements. Added a `HasWeight` interface to enforce this.

2. Add a `simpleWeight` field to all objects that have a simple field. Since the query in a simple field propagates to all objects below it in the query hierarchy, this allows users to control the weights of each of those fields. Added a `HasSimple` interface to support this.