### PR TITLE
Serialization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.citrine</groupId>
     <artifactId>jcc</artifactId>
-    <version>2.11.2</version>
+    <version>2.11.3</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/io/citrine/jcc/core/CitrinationClient.java
+++ b/src/main/java/io/citrine/jcc/core/CitrinationClient.java
@@ -13,7 +13,7 @@ import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
-import org.apache.http.entity.StringEntity;
+import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.LaxRedirectStrategy;
@@ -103,7 +103,7 @@ public class CitrinationClient {
         final HttpPost post = new HttpPost(this.host + "/api/search/pif_search");
         post.addHeader("X-API-Key", this.apiKey);
         post.addHeader("Content-type", "application/json");
-        post.setEntity(new StringEntity(OBJECT_MAPPER.writeValueAsString(pifQuery)));
+        post.setEntity(new ByteArrayEntity(OBJECT_MAPPER.writeValueAsBytes(pifQuery)));
         return post;
     }
 
@@ -129,7 +129,7 @@ public class CitrinationClient {
         final HttpPost post = new HttpPost(this.host + "/api/search/pif/multi_pif_search");
         post.addHeader("X-API-Key", this.apiKey);
         post.addHeader("Content-type", "application/json");
-        post.setEntity(new StringEntity(OBJECT_MAPPER.writeValueAsString(multiQuery)));
+        post.setEntity(new ByteArrayEntity(OBJECT_MAPPER.writeValueAsBytes(multiQuery)));
         return post;
     }
 

--- a/src/test/java/io/citrine/jcc/search/pif/query/PifSystemReturningQueryIT.java
+++ b/src/test/java/io/citrine/jcc/search/pif/query/PifSystemReturningQueryIT.java
@@ -8,6 +8,7 @@ import io.citrine.jcc.search.core.query.Filter;
 import io.citrine.jcc.search.core.query.MultiQuery;
 import io.citrine.jcc.search.core.result.MultiSearchResult;
 import io.citrine.jcc.search.pif.query.core.FieldQuery;
+import io.citrine.jcc.search.pif.query.core.PropertyQuery;
 import io.citrine.jcc.search.pif.result.PifSearchHit;
 import io.citrine.jcc.search.pif.result.PifSearchResult;
 import org.junit.Assert;
@@ -145,5 +146,24 @@ public class PifSystemReturningQueryIT extends CitrinationClientITBase {
         // Make sure that an analysis came back
         Assert.assertNotNull(pifSearchResult.getAnalysis("name"));
         Assert.assertEquals(1, ((CategoricalAnalysisResult) pifSearchResult.getAnalysis("name")).bucketsLength());
+    }
+
+    /**
+     * Run a query with a degree unicode character in it. This is a regression test to make sure that we are
+     * serializing in a way that the server will respect.
+     *
+     * @throws IOException if thrown while making search requests. This should be thrown if the degree symbol is not
+     * properly serialized when making the request.
+     */
+    @Test
+    public void testDegreeSymbol() throws IOException {
+        this.client.search(new PifSystemReturningQuery()
+                .setSize(0)
+                .addQuery(new DataQuery()
+                        .addSystem(new PifSystemQuery()
+                                .addProperties(new PropertyQuery()
+                                        .addUnits(new FieldQuery()
+                                                .addFilter(new Filter()
+                                                        .setEqual("°")))))));
     }
 }


### PR DESCRIPTION
There were deserialization issues on the server when serializing requests as strings. This was resolved by serializing to byte arrays. This adds a regression test to make sure that the offending characters continues to work as expected.